### PR TITLE
default comparsion time is one year behind for air quality data

### DIFF
--- a/app/src/config/esa.js
+++ b/app/src/config/esa.js
@@ -113,10 +113,12 @@ export const indicatorsDefinition = Object.freeze({
       label: 'Sentinel-5p Mapping Service',
       url: 'https://maps.s5p-pal.com',
     },
+    largeTimeDuration: true,
   },
   N2: {
     indicator: 'CO2 emissions',
     class: 'environment',
+    largeTimeDuration: true,
   },
   N3: {
     indicator: 'CHL concentration',

--- a/app/src/config/trilateral.js
+++ b/app/src/config/trilateral.js
@@ -102,11 +102,13 @@ export const indicatorsDefinition = Object.freeze({
       label: 'Sentinel-5p Mapping Service',
       url: 'https://maps.s5p-pal.com',
     },
+    largeTimeDuration: true,
   },
   N1NASA: {
     indicator: 'NO2 Concentration (OMI)',
     class: 'environment',
     story: '/data/trilateral/N1',
+    largeTimeDuration: true,
   },
   NASAPopulation: {
     indicator: 'Population',
@@ -116,6 +118,7 @@ export const indicatorsDefinition = Object.freeze({
     indicator: 'CO2 emissions (GOSAT)',
     class: 'environment',
     file: '/data/trilateral/N2.csv',
+    largeTimeDuration: true,
   },
   N3: {
     indicator: 'CHL concentration (CMEMS)',


### PR DESCRIPTION
new config in indicator definition: `largeTimeDuration:true` enables that compare image time selection is preset at closest time one year earlier

otherwise use first time entry as before