### PR TITLE
add layermapping as another source of map defaults for indicator map

### DIFF
--- a/app/src/components/IndicatorMap.vue
+++ b/app/src/components/IndicatorMap.vue
@@ -281,7 +281,10 @@ export default {
       return this.baseConfig.overlayLayers;
     },
     mapDefaults() {
-      return this.baseConfig.mapDefaults;
+      return {
+        ...this.baseConfig.mapDefaults,
+        ...this.shLayerConfig('data'),
+      };
     },
     layerNameMapping() {
       return this.baseConfig.layerNameMapping;


### PR DESCRIPTION
this allows to set for example maxMapZoom, minMapZoom or bounds per 
layer