### PR TITLE
rounding decimals

### DIFF
--- a/app/src/components/IndicatorData.vue
+++ b/app/src/components/IndicatorData.vue
@@ -611,7 +611,8 @@ export default {
     roundValueInd(val) {
       if (this.indDefinition.maxDecimals === -1) {
         return val;
-      } else if (!Number.isNaN(this.indDefinition.maxDecimals)) {
+      }
+      if (Number.isInteger(this.indDefinition.maxDecimals)) {
         return this.formatNumRef(val, this.indDefinition.maxDecimals);
       }
       // use default
@@ -999,6 +1000,18 @@ export default {
           enabled: true,
           mode: 'x',
         },
+        tooltips: {
+          callbacks: {
+            label: function(context, data) {
+              let label = data.datasets[context.datasetIndex].label || '';
+              if (label) {
+                label += ': ';
+              }
+              label += this.roundValueInd(Number(context.value));
+              return label;
+            }.bind(this),
+          },
+        }
       };
 
       if (['N3'].includes(indicatorCode)) {

--- a/app/src/components/IndicatorData.vue
+++ b/app/src/components/IndicatorData.vue
@@ -608,6 +608,15 @@ export default {
     formatNumRef(num, maxDecimals = 3) {
       return Number.parseFloat(num.toFixed(maxDecimals));
     },
+    roundValueInd(val) {
+      if (this.indDefinition.maxDecimals === -1) {
+        return val;
+      } else if (!Number.isNaN(this.indDefinition.maxDecimals)) {
+        return this.formatNumRef(val, this.indDefinition.maxDecimals);
+      }
+      // use default
+      return this.formatNumRef(val, 2);
+    },
     getMinMaxDate(timeData) {
       let timeMin = Math.min.apply(null, timeData.map((d) => d.toMillis()));
       let timeMax = Math.max.apply(null, timeData.map((d) => d.toMillis()));

--- a/app/src/components/IndicatorData.vue
+++ b/app/src/components/IndicatorData.vue
@@ -1002,7 +1002,7 @@ export default {
         },
         tooltips: {
           callbacks: {
-            label: function(context, data) {
+            label: function (context, data) {
               let label = data.datasets[context.datasetIndex].label || '';
               if (label) {
                 label += ': ';
@@ -1011,7 +1011,7 @@ export default {
               return label;
             }.bind(this),
           },
-        }
+        },
       };
 
       if (['N3'].includes(indicatorCode)) {

--- a/app/src/config/esa.js
+++ b/app/src/config/esa.js
@@ -97,7 +97,6 @@ export const indicatorsDefinition = Object.freeze({
     class: 'agriculture',
     story: '/eodash-data/stories/E10a2',
     largeSubAoi: true,
-    maxDecimals: 4,
   },
   E10a5: {
     indicator: 'Harvesting activity',

--- a/app/src/config/esa.js
+++ b/app/src/config/esa.js
@@ -90,12 +90,14 @@ export const indicatorsDefinition = Object.freeze({
     class: 'agriculture',
     story: '/eodash-data/stories/E10a2',
     largeSubAoi: true,
+    maxDecimals: 4,
   },
   E10a3: {
     indicator: 'Evolution of the cultivated areas for production of white asparagus',
     class: 'agriculture',
     story: '/eodash-data/stories/E10a2',
     largeSubAoi: true,
+    maxDecimals: 4,
   },
   E10a5: {
     indicator: 'Harvesting activity',
@@ -114,6 +116,7 @@ export const indicatorsDefinition = Object.freeze({
     class: 'agriculture',
     story: '/eodash-data/stories/E10a7',
     largeSubAoi: true,
+    maxDecimals: 4,
   },
   E10a8: {
     indicator: 'Cumulative harvested area',


### PR DESCRIPTION
- will make it configurable so that by default, it rounds to 2 decimals for tooltips, but we will be able to set per-indicator-type number of decimals to any number or set it to -1 to disable this behavior completely. Config allowing this is in `indicatorsDefinition.<indicator>.maxDecimals`.
- individual tooltip definitions used in indicatorData (like for E10a8) will still overwrite this behavior completely
- data downloadable would download the full values