### PR TITLE
Prevent menu from displaying over fullscreen dialog

### DIFF
--- a/app/src/scss/global.scss
+++ b/app/src/scss/global.scss
@@ -60,6 +60,11 @@
   background: #fff;
 }
 
+// prevent menu items from displaying over dialog
+.v-menu__content {
+  z-index: 201 !important;
+}
+
 .v-application.theme--dark {
   .md-body {
     h1,


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/26576876/101387100-48b9a600-38be-11eb-8f1b-a3745156c4fe.png)


after
![image](https://user-images.githubusercontent.com/26576876/101387193-65ee7480-38be-11eb-9a45-f9f50615a57a.png)
