### PR TITLE
Fix fullscreen mode on Safari and iOS

### DIFF
--- a/app/src/components/DataPanel.vue
+++ b/app/src/components/DataPanel.vue
@@ -118,6 +118,7 @@
           sm="5"
           class="py-0 my-0 d-flex align-center"
           :class="$vuetify.breakpoint.xsOnly ? 'justify-center' : 'justify-space-between'"
+          v-if="!isFullScreen"
         >
           <small v-if="indicatorObject && indicatorObject.updateFrequency">
             <span
@@ -134,6 +135,7 @@
           cols="12"
           sm="7"
           class="py-0 my-0"
+          v-if="!isFullScreen"
         >
           <div :class="$vuetify.breakpoint.xsOnly ? 'text-center' : 'text-right'">
             <v-btn
@@ -143,7 +145,7 @@
               :href="dataHrefCSV"
               :download="downloadFileName"
               target="_blank"
-              v-if="indicatorObject && !showMap"
+              v-if="indicatorObject && !showMap && !isFullScreen"
             >
               <v-icon left>mdi-download</v-icon>
               download csv
@@ -155,6 +157,7 @@
           cols="12"
           ref="customAreaIndicator"
           class="pa-0"
+          v-if="!isFullScreen"
         >
           <v-card
             v-if="customAreaIndicator"
@@ -181,7 +184,7 @@
         <v-col
           cols="12"
         >
-        <div>
+        <div v-if="!isFullScreen">
             <expandable-content>
               <div
                 v-html="story"
@@ -281,6 +284,7 @@ export default {
       'appConfig',
       'baseConfig',
     ]),
+    ...mapState(['isFullScreen']),
     story() {
       let markdown;
       try {
@@ -435,5 +439,14 @@ export default {
 }
 .chart {
   background: #fff;
+}
+
+.v-card.fullscreenElement {
+  position: fixed !important;
+  top: 0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  height: 100vh !important;
 }
 </style>

--- a/app/src/components/DataPanel.vue
+++ b/app/src/components/DataPanel.vue
@@ -2,7 +2,7 @@
   <div style="height: auto;"
     :style="$vuetify.breakpoint.mdAndDown && 'padding-bottom: 100px'"
   >
-    <v-container class="pt-0" :class="showFullScreen && 'showFullScreenButton'">
+    <v-container class="pt-0">
       <v-row v-if="indicatorObject">
         <v-col
           cols="12"
@@ -41,7 +41,7 @@
                 class="fill-height"
                 :style="`height: ${$vuetify.breakpoint.mdAndUp ? (expanded ? 70 : 40) : 60}vh;`"
               >
-                <full-screen-button v-if="showFullScreen" />
+                <full-screen-button />
                 <div
                   style="height: 100%;z-index: 500; position: relative;"
                   v-if="$vuetify.breakpoint.mdAndDown && !dataInteract"
@@ -81,7 +81,7 @@
             class="fill-height"
             :style="`height: ${$vuetify.breakpoint.mdAndUp ? (expanded ? 70 : 40) : 60}vh;`"
           >
-            <full-screen-button v-if="showFullScreen" />
+            <full-screen-button />
             <div
               style="height: 100%;z-index: 500; position: relative;"
               v-if="$vuetify.breakpoint.mdAndDown && !dataInteract"
@@ -281,11 +281,6 @@ export default {
       'appConfig',
       'baseConfig',
     ]),
-    showFullScreen() {
-      const isSafari = !!navigator.userAgent.match(/Version\/[\d\.]+.*Safari/); // eslint-disable-line
-      const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
-      return !isSafari && !iOS;
-    },
     story() {
       let markdown;
       try {

--- a/app/src/components/FullScreenButton.vue
+++ b/app/src/components/FullScreenButton.vue
@@ -24,6 +24,7 @@
 <script>
 import fullscreen from 'vue-fullscreen';
 import Vue from 'vue';
+import { mapState } from 'vuex';
 
 Vue.use(fullscreen);
 
@@ -33,6 +34,9 @@ export default {
     fullScreenElement: null,
     touch: false,
   }),
+  computed: {
+    ...mapState(['isFullScreen'])
+  },
   mounted() {
     this.$nextTick(() => {
       this.touch = window.L.Browser.touch;
@@ -43,10 +47,14 @@ export default {
       // Toggle fullscreen Element in the container element
       const { parentElement } = event.target.closest('.v-btn');
       this.fullScreenElement = parentElement;
-      this.$fullscreen.toggle(parentElement, {
-        wrap: false,
-        callback: this.fullscreenChange,
-      });
+      if(this.$fullscreen.support) {
+        this.$fullscreen.toggle(parentElement, {
+          wrap: false,
+          callback: this.fullscreenChange,
+        });
+      } else {
+        this.fullscreenChange(!this.isFullScreen);
+      }
     },
     fullscreenChange(fullscreenActive) {
       this.fullscreen = fullscreenActive;
@@ -58,6 +66,7 @@ export default {
         app.classList.remove('fullScreenActive');
         this.fullScreenElement.classList.remove('fullscreenElement');
       }
+      this.$store.commit('changeFullScreen', fullscreenActive);
     },
   },
 };

--- a/app/src/components/FullScreenButton.vue
+++ b/app/src/components/FullScreenButton.vue
@@ -67,6 +67,9 @@ export default {
         this.fullScreenElement.classList.remove('fullscreenElement');
       }
       this.$store.commit('changeFullScreen', fullscreenActive);
+      this.$nextTick(() => {
+        window.dispatchEvent(new Event('resize')); // Fixes Safari bug(#810)
+      })
     },
   },
 };

--- a/app/src/components/FullScreenButton.vue
+++ b/app/src/components/FullScreenButton.vue
@@ -17,7 +17,7 @@
           : 'mdi-fullscreen' }}</v-icon>
       </v-btn>
     </template>
-    <span>Full screen</span>
+    <span v-if="!isFullScreen">Full screen</span>
   </v-tooltip>
 </template>
 

--- a/app/src/store/index.js
+++ b/app/src/store/index.js
@@ -14,10 +14,16 @@ const store = new Vuex.Store({
   },
   state: {
     packageVersion: process.env.PACKAGE_VERSION || '0',
+    isFullScreen: false,
   },
   getters: {
     appVersion: (state) => state.packageVersion,
   },
+  mutations: {
+    changeFullScreen(state, val) {
+      state.isFullScreen = val;
+    }
+  }
 });
 
 export default store;

--- a/app/src/views/Dashboard.vue
+++ b/app/src/views/Dashboard.vue
@@ -7,6 +7,7 @@
       flat
       color="primary"
       class="white--text"
+      v-show="!isFullScreen"
     >
       <v-app-bar-nav-icon @click.stop="drawerLeft = !drawerLeft" dark />
       <v-toolbar-title
@@ -44,6 +45,7 @@
       clipped
       style="overflow: hidden"
       class="drawerLeft"
+      v-show="!isFullScreen"
     >
       <template v-if="$vuetify.breakpoint.xsOnly">
         <v-list-item style="background: var(--v-primary-base)">
@@ -152,6 +154,7 @@
       hide-overlay
       transition="dialog-bottom-transition"
       style="overflow:hidden"
+      v-show="!isFullScreen"
     >
       <v-toolbar dark color="primary">
         <v-toolbar-title style="overflow: unset; white-space: pre-wrap;"
@@ -219,7 +222,7 @@
         </v-row>
       </v-container>
     </v-content>
-    <global-footer />
+    <global-footer v-if="!isFullScreen"/>
   </div>
 </template>
 
@@ -233,6 +236,7 @@ import DataPanel from '@/components/DataPanel.vue';
 import GlobalFooter from '@/components/GlobalFooter.vue';
 import closeMixin from '@/mixins/close';
 import dialogMixin from '@/mixins/dialogMixin';
+import { mapState } from 'vuex';
 
 export default {
   metaInfo() {
@@ -292,6 +296,7 @@ export default {
     theme() {
       return (this.$vuetify.theme.dark) ? 'dark' : 'light';
     },
+    ...mapState(['isFullScreen'])
   },
   created() {
     this.drawerLeft = this.$vuetify.breakpoint.mdAndUp;


### PR DESCRIPTION
Fixes #689.

The following changes were made:
1) The code that hides the fullscreen button on Safari and iOS was removed.
2) A new property, `isFullScreen` was added on the root Vuex store.
3) Added code logic that hides the header, the left sidebar, the footer as well as some other mobile elements when `isFullScreen` is toggled on.
4) iPhone does not support fullscreen(more on that [here](https://stackoverflow.com/a/46544156/8157383)). I manually trigger fullscreen on such devices without using `vue-fullscreen`