### PR TITLE
fix: keep indicator map (but hide it) to fix #828

### DIFF
--- a/app/src/components/DataPanel.vue
+++ b/app/src/components/DataPanel.vue
@@ -152,6 +152,12 @@
                 down: () => swipe(),
             }">
             </div>
+            <indicator-map
+              ref="indicatorMap"
+              style="top: 0px; position: absolute;"
+              v-show="false"
+              class="pt-0 fill-height"
+            />
             <indicator-data
               v-if="!customAreaIndicator.isEmpty"
               style="margin-top: 0px;"
@@ -580,7 +586,9 @@ export default {
       this.$vuetify.goTo(this.$refs.customAreaIndicator, { container: document.querySelector('.data-panel') });
     },
     clearSelection() {
-      const refMap = this.$refs.indicatorMap[this.selectedSensorTab];
+      const refMap = Array.isArray(this.$refs.indicatorMap)
+        ? this.$refs.indicatorMap[this.selectedSensorTab]
+        : this.$refs.indicatorMap;
       refMap.selectedCountry = null;
       refMap.selecectedLayer = null;
       this.$store.state.indicators.customAreaIndicator = null;


### PR DESCRIPTION
The [clearSelection()](https://github.com/eurodatacube/eodash/blob/fix-custom-area-close/app/src/components/DataPanel.vue#L588) function references `this.$refs.indicatorMap` which is not rendered in the case of `customAreaIndicator && !expanded` in the [original code](https://github.com/eurodatacube/eodash/blob/staging/app/src/components/DataPanel.vue#L123). 

Therefore I added an [invisible indicatorMap](https://github.com/eurodatacube/eodash/blob/fix-custom-area-close/app/src/components/DataPanel.vue#L155), and an [additional check](https://github.com/eurodatacube/eodash/blob/fix-custom-area-close/app/src/components/DataPanel.vue#L589) if there are multiple indicatorMaps or just this single one.