### PR TITLE
Bug fix for archived indicator filter in url not working

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -134,8 +134,15 @@ export default {
         // validate query for country - need to be among available
         const selectedCountry = this.getCountryItems
           .map((item) => item.code).flat().find((f) => f === country);
-        const selectedIndicator = this.getIndicators
+        let selectedIndicator = this.getIndicators
           .map((item) => item.code).find((f) => f === indicator);
+        // If selectedIndicator is undefined it could be an archived indicator
+        // so we activate them here and look again
+        if (typeof selectedIndicator === 'undefined') {
+          this.$store.commit('features/SET_FEATURE_FILTER', { includeArchived: true });
+          selectedIndicator = this.getIndicators
+            .map((item) => item.code).find((f) => f === indicator);
+        }
         this.$store.commit('features/INIT_FEATURE_FILTER', {
           countries: selectedCountry,
           indicators: selectedIndicator,

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -131,7 +131,6 @@ export default {
         // Read route query and validate country and indicator if in query
         const { country } = this.$route.query;
         const { indicator } = this.$route.query;
-        console.log(indicator);
         // validate query for country - need to be among available
         const selectedCountry = this.getCountryItems
           .map((item) => item.code).flat().find((f) => f === country);

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -131,14 +131,15 @@ export default {
         // Read route query and validate country and indicator if in query
         const { country } = this.$route.query;
         const { indicator } = this.$route.query;
+        console.log(indicator);
         // validate query for country - need to be among available
         const selectedCountry = this.getCountryItems
           .map((item) => item.code).flat().find((f) => f === country);
         let selectedIndicator = this.getIndicators
           .map((item) => item.code).find((f) => f === indicator);
-        // If selectedIndicator is undefined it could be an archived indicator
-        // so we activate them here and look again
-        if (typeof selectedIndicator === 'undefined') {
+        // If selectedIndicator is undefined and indicator has been provided
+        // it could be an archived indicator so we activate
+        if (typeof indicator !== 'undefined' && typeof selectedIndicator === 'undefined') {
           this.$store.commit('features/SET_FEATURE_FILTER', { includeArchived: true });
           selectedIndicator = this.getIndicators
             .map((item) => item.code).find((f) => f === indicator);


### PR DESCRIPTION
added check to look for archived indicators if provided indicator in url is not found in non archived indicators.
Fixes #945 