### PR TITLE
Fix infinite loop

### DIFF
--- a/app/src/components/IndicatorData.vue
+++ b/app/src/components/IndicatorData.vue
@@ -977,7 +977,7 @@ export default {
         || this.$store.state.indicators.customAreaIndicator
         || this.$store.state.indicators.selectedIndicator;
       // only do this on custom AOIs otherwise we get infinite loop
-      if (indicatorObject.hasOwnProperty('aoi')) {
+      if (Object.prototype.hasOwnProperty.call(indicatorObject, 'aoi')) {
         indicatorObject.time = indicatorObject.time.map(
           (d) => (DateTime.isDateTime(d) ? d : DateTime.fromISO(d)),
         );

--- a/app/src/components/IndicatorData.vue
+++ b/app/src/components/IndicatorData.vue
@@ -976,10 +976,12 @@ export default {
       const indicatorObject = this.currentIndicator
         || this.$store.state.indicators.customAreaIndicator
         || this.$store.state.indicators.selectedIndicator;
-
-      indicatorObject.time = indicatorObject.time.map(
-        (d) => (DateTime.isDateTime(d) ? d : DateTime.fromISO(d)),
-      );
+      // only do this on custom AOIs otherwise we get infinite loop
+      if (indicatorObject.hasOwnProperty('aoi')) {
+        indicatorObject.time = indicatorObject.time.map(
+          (d) => (DateTime.isDateTime(d) ? d : DateTime.fromISO(d)),
+        );
+      }
 
       return indicatorObject;
     },


### PR DESCRIPTION
- only loops through `indicatorObject.times` in custom AOIs to prevent infinite loops on other indicators