### PR TITLE
fix: infinite loop on time formatting

### DIFF
--- a/app/src/components/CustomDashboardGrid.vue
+++ b/app/src/components/CustomDashboardGrid.vue
@@ -242,6 +242,7 @@
 </template>
 
 <script>
+import { DateTime } from 'luxon';
 import IndicatorData from '@/components/IndicatorData.vue';
 import IndicatorMap from '@/components/IndicatorMap.vue';
 import LoadingAnimation from '@/components/LoadingAnimation.vue';
@@ -307,7 +308,20 @@ export default {
             firstCall = true;
           }
           this.features = await Promise.all(features.map(async (f) => {
-            if (f.includesIndicator || f.text) return f;
+            if (f.includesIndicator) {
+              const convertedTimes = f.indicatorObject.time.map(
+                (d) => (DateTime.isDateTime(d) ? d : DateTime.fromISO(d)),
+              );
+              return {
+                ...f,
+                indicatorObject: {
+                  ...f.indicatorObject,
+                  time: convertedTimes,
+                }
+              };
+            } else if (f.text) {
+              return f;
+            }
 
             const feature = this.$store.state.features.allFeatures
               .find((i) => this.getLocationCode(i.properties.indicatorObject) === f.poi);
@@ -315,7 +329,7 @@ export default {
               this.baseConfig,
               feature.properties.indicatorObject,
             );
-
+            
             if (f.mapInfo && (firstCall || f.poi === this.savedPoi)) {
               this.$set(this.localZoom, f.poi, f.mapInfo.zoom);
               this.$set(this.localCenter, f.poi, f.mapInfo.center);

--- a/app/src/components/IndicatorData.vue
+++ b/app/src/components/IndicatorData.vue
@@ -973,17 +973,9 @@ export default {
       return dataCollection;
     },
     indicatorObject() {
-      const indicatorObject = this.currentIndicator
+      return this.currentIndicator
         || this.$store.state.indicators.customAreaIndicator
         || this.$store.state.indicators.selectedIndicator;
-      // only do this on custom AOIs otherwise we get infinite loop
-      if (Object.prototype.hasOwnProperty.call(indicatorObject, 'aoi')) {
-        indicatorObject.time = indicatorObject.time.map(
-          (d) => (DateTime.isDateTime(d) ? d : DateTime.fromISO(d)),
-        );
-      }
-
-      return indicatorObject;
     },
     indDefinition() {
       return this.baseConfig.indicatorsDefinition[this.indicatorObject.indicator];


### PR DESCRIPTION
Moved time formatting from `IndicatorData.vue` to `CustomDashboardGrid.vue` in order to cleanly format the `indicatorObject.time` value for indicators that need it and prevent infinite loops