### PR TITLE
Add disclaimer and reference to tos for unofficial custom dashboards

### DIFF
--- a/app/src/views/DashboardCustom.vue
+++ b/app/src/views/DashboardCustom.vue
@@ -98,6 +98,14 @@
                 </v-card>
               </v-dialog>
             </div>
+            <p v-if="newDashboard || hasEditingPrivilege">
+              Disclaimer: By editing, saving and sharing this custom dashboard, you agree to not include any content that suggest affiliation with the <strong>{{ $store.state.config.appConfig.branding.appName }}</strong> providers (such as logos).
+              A violation of this agreement will result in the deletion of this custom dashboard without warning.<br />
+              <small>For additional information, see article 8.5 (logo usage) of the <a href="/terms_and_conditions" target="_blank">Terms and Conditions of this website</a>.</small>
+            </p>
+            <p v-else>
+              <em>This Custom Dashboard was user-generated and is not affiliated with the {{ $store.state.config.appConfig.branding.appName }} providers.</em>
+            </p>
           </div>
         </v-col>
         <v-col

--- a/app/src/views/DashboardCustom.vue
+++ b/app/src/views/DashboardCustom.vue
@@ -100,10 +100,11 @@
             </div>
             <p v-if="newDashboard || hasEditingPrivilege">
               Disclaimer: By editing, saving and sharing this custom dashboard, you agree to the
-              <a href="/terms_and_conditions" target="_blank">
-                Terms and Conditions of this website
-              </a>. Any violation of this agreement will result in
-              the deletion of this custom dashboard without warning.
+              <a
+                href="/terms_and_conditions"
+                target="_blank"
+              >Terms and Conditions of this website</a>. Any violation of this agreement will
+              result in the deletion of this custom dashboard without warning.
             </p>
             <p v-else>
               <em>
@@ -111,12 +112,8 @@
                 {{ $store.state.config.appConfig.branding.appName }} project. Some of the content
                 on this page originates from the
                 {{ $store.state.config.appConfig.branding.appName }},
-                <a :href="rootLink" target="_blank">
-                  {{ rootLink }}
-                </a>.
-                <a href="/terms_and_conditions" target="_blank">
-                  Terms and Conditions
-                </a> apply.
+                <a :href="rootLink" target="_blank">{{ rootLink }}</a>.
+                <a href="/terms_and_conditions" target="_blank">Terms and Conditions</a> apply.
               </em>
             </p>
           </div>

--- a/app/src/views/DashboardCustom.vue
+++ b/app/src/views/DashboardCustom.vue
@@ -99,21 +99,25 @@
               </v-dialog>
             </div>
             <p v-if="newDashboard || hasEditingPrivilege">
-              Disclaimer: By editing, saving and sharing this custom dashboard, you agree to not
-              include any content that suggest affiliation with the
-              <strong>{{ $store.state.config.appConfig.branding.appName }}</strong>
-              providers (such as logos). A violation of this agreement will result in the deletion
-              of this custom dashboard without warning.<br />
-              <small>
-                For additional information, see article 8.5 (logo usage) of the
-                <a href="/terms_and_conditions" target="_blank">
-                  Terms and Conditions of this website
-                </a>.
-              </small>
+              Disclaimer: By editing, saving and sharing this custom dashboard, you agree to the
+              <a href="/terms_and_conditions" target="_blank">
+                Terms and Conditions of this website
+              </a>. Any violation of this agreement will result in
+              the deletion of this custom dashboard without warning.
             </p>
             <p v-else>
-              <em>This Custom Dashboard was user-generated and is not affiliated with
-                the {{ $store.state.config.appConfig.branding.appName }} providers.</em>
+              <em>
+                This Custom Dashboard was user-generated and is not an official product of the
+                {{ $store.state.config.appConfig.branding.appName }} project. Some of the content
+                on this page originates from the
+                {{ $store.state.config.appConfig.branding.appName }},
+                <a :href="rootLink" target="_blank">
+                  {{ rootLink }}
+                </a>.
+                <a href="/terms_and_conditions" target="_blank">
+                  Terms and Conditions
+                </a> apply.
+              </em>
             </p>
           </div>
         </v-col>
@@ -561,6 +565,9 @@ export default {
         && this.$store.state.dashboard.dashboardConfig.id)
         ? `${window.location.origin}/dashboard?id=${this.$store.state.dashboard.dashboardConfig.id}&editKey=${this.$store.state.dashboard.dashboardConfig.editKey}`
         : 'Loading...';
+    },
+    rootLink() {
+      return document.location.origin;
     },
   },
   async created() {

--- a/app/src/views/DashboardCustom.vue
+++ b/app/src/views/DashboardCustom.vue
@@ -31,7 +31,7 @@
         <img class="header__logo" :src="appConfig && appConfig.branding.headerLogo" />
       </v-app-bar>
       <v-row class="d-flex">
-        <v-col cols="12" md="6">
+        <v-col cols="12" md="6" xl="8">
           <div class="dashboardTitle">
             <div class="d-flex">
               <h1
@@ -120,6 +120,7 @@
         <v-col
           cols="12"
           md="6"
+          xl="4"
           class="d-flex align-center"
         >
           <div

--- a/app/src/views/DashboardCustom.vue
+++ b/app/src/views/DashboardCustom.vue
@@ -99,12 +99,21 @@
               </v-dialog>
             </div>
             <p v-if="newDashboard || hasEditingPrivilege">
-              Disclaimer: By editing, saving and sharing this custom dashboard, you agree to not include any content that suggest affiliation with the <strong>{{ $store.state.config.appConfig.branding.appName }}</strong> providers (such as logos).
-              A violation of this agreement will result in the deletion of this custom dashboard without warning.<br />
-              <small>For additional information, see article 8.5 (logo usage) of the <a href="/terms_and_conditions" target="_blank">Terms and Conditions of this website</a>.</small>
+              Disclaimer: By editing, saving and sharing this custom dashboard, you agree to not
+              include any content that suggest affiliation with the
+              <strong>{{ $store.state.config.appConfig.branding.appName }}</strong>
+              providers (such as logos). A violation of this agreement will result in the deletion
+              of this custom dashboard without warning.<br />
+              <small>
+                For additional information, see article 8.5 (logo usage) of the
+                <a href="/terms_and_conditions" target="_blank">
+                  Terms and Conditions of this website
+                </a>.
+              </small>
             </p>
             <p v-else>
-              <em>This Custom Dashboard was user-generated and is not affiliated with the {{ $store.state.config.appConfig.branding.appName }} providers.</em>
+              <em>This Custom Dashboard was user-generated and is not affiliated with
+                the {{ $store.state.config.appConfig.branding.appName }} providers.</em>
             </p>
           </div>
         </v-col>


### PR DESCRIPTION
This PR adds some information during editing and viewing mode of custom dashboards.  

Editing mode:
![grafik](https://user-images.githubusercontent.com/26576876/141990664-e35baaf9-9b87-434d-ae89-48377b5ba7d6.png)


Viewing mode:
![grafik](https://user-images.githubusercontent.com/26576876/141990621-585e416a-02e8-49b6-a549-3adafa72490f.png)


Closes #1038
See https://github.com/eurodatacube/eodash/issues/1040#issuecomment-929128346