### PR TITLE
Mandatory absolute paths for Sentinel Hub Config and other assets

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -36,7 +36,7 @@
     <!-- End loader -->
 
     <!-- Inject Sentinel Hub Config -->
-    <script src="./shConfig.js"></script>
+    <script src="/shConfig.js"></script>
 
     <div id="app"></div>
     <!-- built files will be auto injected -->

--- a/app/src/appConfig.js
+++ b/app/src/appConfig.js
@@ -160,7 +160,7 @@ module.exports = [
       appName: 'Earth Observing Dashboard',
       primaryColor: '#333333',
       secondaryColor: '#004170',
-      headerLogo: './data/trilateral/Trilateral_Logo.svg',
+      headerLogo: '/data/trilateral/Trilateral_Logo.svg',
       faviconPath: './public/img/trilateral/favicon.ico',
     },
     pageMeta: {


### PR DESCRIPTION
IMPORTANT!

When the user externally accesses a route with a dynamic segment, the app stops loading assets referenced by relative path correctly. The path is appended onto the route, breaking the links. This leads to broken agency images in the best case and a **_totally unusable site_** in the worst case.

To reproduce this error, try accessing [https://eodashboard.org/dashboard/247?](https://eodashboard.org/dashboard/247?)

Since `shConfig.js` is being fetched from the wrong URL, the Vue router returns a 404 page which is then wrongly interpreted as JavaScript by the browser.

This pull request fixes the broken references to the trilateral logo image and the Sentinel Hub Configuration.

