### PR TITLE
fix: reduce CPU usage drastically by disabling polling and not watchi…

### DIFF
--- a/app/vue.config.js
+++ b/app/vue.config.js
@@ -53,6 +53,12 @@ module.exports = {
     'vuetify',
   ],
   configureWebpack: {
+    devServer: {
+      watchOptions: {
+        poll: false,
+        ignored: /node_modules/,
+      },
+    },
     module: {
       rules: [{
         test: /\.md$/,


### PR DESCRIPTION
This change reduces the idle load caused by the Webpack file watching system drastically, removing unnecessary strain from both CPU and battery. 