### PR TITLE
Fix loading indicator and catch errors when saving new custom dashboard

### DIFF
--- a/app/src/views/DashboardCustom.vue
+++ b/app/src/views/DashboardCustom.vue
@@ -677,17 +677,23 @@ export default {
         await this.addMarketingInfo({
           interests: this.interests,
         });
-        await this.addToMailingList({
-          email: this.email,
-          name: this.name,
-          listId: this.$store.state.config.appConfig.mailingList[process.env.NODE_ENV],
-          newsletterOptIn: this.newsletterOptIn,
-          dashboardId: this.$store.state.dashboard.dashboardConfig.id,
-          dashboardURLView: this.viewingLink,
-          dashboardURLEdit: this.editingLink,
-          dashboardTitle: this.dashboardTitle,
-          interests: this.interests,
-        });
+
+        try {
+          await this.addToMailingList({
+            email: this.email,
+            name: this.name,
+            listId: this.$store.state.config.appConfig.mailingList[process.env.NODE_ENV],
+            newsletterOptIn: this.newsletterOptIn,
+            dashboardId: this.$store.state.dashboard.dashboardConfig.id,
+            dashboardURLView: this.viewingLink,
+            dashboardURLEdit: this.editingLink,
+            dashboardTitle: this.dashboardTitle,
+            interests: this.interests,
+          });
+        } catch (e) {
+          console.log(`could not add to mailing list: ${e}`)
+        }
+
         this.$router.replace({
           path: 'dashboard',
           query: {

--- a/app/src/views/DashboardCustom.vue
+++ b/app/src/views/DashboardCustom.vue
@@ -670,7 +670,7 @@ export default {
       }
     },
     async submitMarketingData() {
-      this.loading = true;
+      this.saving = true;
       this.performChange('changeTitle', this.popupTitle);
       if (this.$refs.form.validate()) {
         this.performChange('changeTitle', this.popupTitle);
@@ -697,7 +697,7 @@ export default {
         });
         this.success = true;
       }
-      this.loading = false;
+      this.saving = false;
     },
     createTextFeature() {
       if (this.$refs.textForm.validate()) {

--- a/app/src/views/DashboardCustom.vue
+++ b/app/src/views/DashboardCustom.vue
@@ -691,7 +691,7 @@ export default {
             interests: this.interests,
           });
         } catch (e) {
-          console.log(`could not add to mailing list: ${e}`)
+          console.log(`could not add to mailing list: ${e}`);
         }
 
         this.$router.replace({


### PR DESCRIPTION
This tiny pull request fixes a typo that would break the form's loading indicator and wraps the `addToMailingList` call in a try/catch block, so it still navigates to the links modal even if the mailing list call fails.

Closes #1257 