### PR TITLE
Subaoi overlay

### DIFF
--- a/app/src/components/map/CenterMap.vue
+++ b/app/src/components/map/CenterMap.vue
@@ -136,6 +136,7 @@ export default {
   font-size: 14px;
   box-shadow: none !important;
   background: rgba(0, 0, 0, 0.6);
+  color: #FFFFFF;
 }
 
 .tooltip:after {

--- a/app/src/components/map/CenterMap.vue
+++ b/app/src/components/map/CenterMap.vue
@@ -6,6 +6,11 @@
       :baseLayers="baseLayers"
       :overlayConfigs="overlayConfigs"
     />
+    <div id="centerMapOverlay" class="tooltip v-card v-sheet text-center pa-2">
+      <p class="ma-0"><strong>{{ tooltip.city }}</strong></p>
+      <p class="ma-0"><strong>{{ tooltip.indicator }}</strong></p>
+      <p class="ma-0"> {{ tooltip.label }} </p>
+    </div>
   </div>
 </template>
 
@@ -14,11 +19,11 @@ import {
   mapGetters,
   mapState,
 } from 'vuex';
-
 import LayerControl from '@/components/map/LayerControl.vue';
 import { createLayerFromConfig } from '@/components/map/layers';
 import Cluster from '@/components/map/Cluster';
 import getMapInstance from '@/components/map/map';
+import { formatLabel } from '@/components/map/formatters';
 
 
 export default {
@@ -41,6 +46,11 @@ export default {
       defaultMapOptions: {
         attributionControl: false,
         zoomControl: false,
+      },
+      tooltip: {
+        city: '',
+        indicator: '',
+        description: '',
       },
       overlayConfigs: [],
       opacityTerrain: [1],
@@ -96,7 +106,7 @@ export default {
       this.updateOverlayOpacity(overlayLayers, view);
 
       const cluster = new Cluster(map, this, this.getGroupedFeatures);
-      cluster.setActive(true);
+      cluster.setActive(true, this.overlayCallback);
       this.$watch('$store.state.indicators.selectedIndicator', () => {
         cluster.reRender();
       });
@@ -112,7 +122,33 @@ export default {
         }
       });
     },
+    overlayCallback(indicatorObject) {
+      this.tooltip = formatLabel(indicatorObject, this);
+    },
   },
   beforeDestroy() {},
 };
 </script>
+<style lang="scss" scoped>
+
+.tooltip {
+  position: relative;
+  font-size: 14px;
+  box-shadow: none !important;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.tooltip:after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border: 10px solid transparent;
+  border-top-color: rgba(0, 0, 0, 0.6);
+  border-bottom: 0;
+  margin-left: -10px;
+  margin-bottom: -10px;
+}
+</style>

--- a/app/src/components/map/Cluster.js
+++ b/app/src/components/map/Cluster.js
@@ -82,11 +82,18 @@ const indicatorClassesStyles = Object.keys(indicatorClassesIcons).reduce((acc, k
     context.fillRect(0, 0, image.width, image.height);
     context.globalCompositeOperation = 'destination-in';
     context.drawImage(image, 0, 0);
-    acc[key] = new Icon({
-      scale: 0.66,
-      img: canvas,
-      imgSize: [image.width, image.height],
-    });
+    acc[key] = {
+      small: new Icon({
+        scale: 0.66,
+        img: canvas,
+        imgSize: [image.width, image.height],
+      }),
+      large: new Icon({
+        scale: 1,
+        img: canvas,
+        imgSize: [image.width, image.height],
+      }),
+    };
     if (Object.keys(acc).length === Object.keys(indicatorClassesIcons).length) {
       onStylesLoaded.forEach((cb) => cb());
       onStylesLoaded = undefined;
@@ -504,10 +511,7 @@ export default class Cluster {
       }),
       geometry: clusterMember.getGeometry(),
     });
-    const image = indicatorClassesStyles[indicator.class];
-    if (image) {
-      image.setScale(isSelected ? 1 : 0.66);
-    }
+    const image = indicatorClassesStyles[indicator.class][isSelected ? 'large' : 'small'];
     const iconStyle = new Style({
       image,
       geometry: clusterMember.getGeometry(),

--- a/app/src/components/map/Cluster.js
+++ b/app/src/components/map/Cluster.js
@@ -14,7 +14,7 @@ import {
 import ClusterSource from 'ol/source/Cluster';
 import VectorSource from 'ol/source/Vector';
 import { asArray } from 'ol/color';
-import { Feature } from 'ol';
+import { Feature, Overlay } from 'ol';
 import { fromLonLat } from 'ol/proj';
 import { getColor } from './olMapColors';
 import { indicatorClassesIcons } from '../../config/trilateral';
@@ -125,6 +125,31 @@ function generatePointsCircle(count, clusterCenter, resolution) {
   return res;
 }
 
+/**
+ * get the cluster member of an (open) cluster feature by calculating the points circle
+ * @param {*} map ol map
+ * @param {*} openClusterFeature cluster feature
+ * @param {Array} coordinate coordinate
+ * @returns {*} Object with feature and calculated coords
+ */
+function getClusterMemberForCoordinate(map, openClusterFeature, coordinate) {
+  const members = openClusterFeature.get('features');
+  const coords = generatePointsCircle(members.length,
+    openClusterFeature.getGeometry().getCoordinates(),
+    map.getView().getResolution());
+  let dist = Infinity;
+  let index;
+  for (let i = 0, ii = coords.length; i < ii; ++i) {
+    const newDist = (coordinate[0] - coords[i][0]) ** 2
+      + (coordinate[1] - coords[i][1]) ** 2;
+    if (newDist < dist) {
+      index = i;
+      dist = newDist;
+    }
+  }
+  return { feature: members[index], coords: coords[index] };
+}
+
 
 /**
  * Style for clusters with features that are too close to each other, activated on click.
@@ -199,20 +224,29 @@ export default class Cluster {
   /**
    * adding layer and interactions if active=true, otherwise removing them from the map
    * @param {boolean} active
+   * @param {Function} overlayCallback callback function for populating overlay
    */
-  setActive(active) {
+  setActive(active, overlayCallback) {
     if (active) {
       [this.clusters, this.clusterHulls, this.clusterCircles].forEach((l) => {
         this.map.addLayer(l);
       });
-      this.map.on('pointermove', this.pointermoveInteraction);
+      this.map.on('pointermove', this.pointermoveInteraction.bind(this, overlayCallback));
       this.map.on('click', this.clickInteraction);
+      const overlay = new Overlay({
+        element: document.getElementById('centerMapOverlay'),
+        id: 'clusterOverlay',
+        offset: [0, -22],
+        positioning: 'bottom-center',
+      });
+      this.map.addOverlay(overlay);
     } else {
       [this.clusters, this.clusterHulls, this.clusterCircles].forEach((l) => {
         this.map.removeLayer(l);
       });
       this.map.un('pointermove', this.pointermoveInteraction);
       this.map.un('click', this.clickInteraction);
+      this.map.getOverlayById('clusterOverlay').setMap(null);
     }
   }
 
@@ -241,42 +275,54 @@ export default class Cluster {
   }
 
   createInteractions() {
-    this.pointermoveInteraction = async (event) => {
-      const singleCircleFeatures = await this.clusterCircles.getFeatures(event.pixel);
+    this.pointermoveInteraction = async (callback, event) => {
+      const openClusterFeatures = await this.clusterCircles.getFeatures(event.pixel);
       const clusterFeatures = await this.clusters.getFeatures(event.pixel);
       if (clusterFeatures[0] !== this.hoverFeature) {
         // Display the convex hull on hover.
         // eslint-disable-next-line prefer-destructuring
         this.hoverFeature = clusterFeatures[0];
         this.clusterHulls.setStyle(this.clusterHullStyle.bind(this));
-        // Change the cursor style to indicate that the cluster is clickable.
       }
+      // Change the cursor style to indicate that the cluster is clickable.
       // eslint-disable-next-line no-param-reassign
-      this.map.getTargetElement().style.cursor = this.hoverFeature || singleCircleFeatures.length
+      this.map.getTargetElement().style.cursor = this.hoverFeature || openClusterFeatures.length
         ? 'pointer'
         : '';
+      // show or hide popup
+      const overlay = this.map.getOverlayById('clusterOverlay');
+      if (openClusterFeatures.length || (this.hoverFeature && this.hoverFeature.get('features').length === 1)) {
+        let coords;
+        let hoverFeature;
+        if (openClusterFeatures.length) {
+          const clusterObject = getClusterMemberForCoordinate(this.map,
+            openClusterFeatures[0],
+            event.coordinate);
+          coords = clusterObject.coords;
+          hoverFeature = clusterObject.feature;
+        } else {
+          [hoverFeature] = this.hoverFeature.get('features');
+          coords = hoverFeature.getGeometry().getCoordinates();
+        }
+        overlay.setMap(this.map);
+        overlay.setPosition(coords);
+        const { indicatorObject } = hoverFeature.getProperties().properties;
+        callback(indicatorObject);
+        overlay.getElement().style.display = 'block';
+      } else {
+        overlay.setMap(null);
+      }
     };
     this.clickInteraction = async (event) => {
       this.clickedClusterMember = undefined;
       // features of expanded clusters
       const openClusterFeatures = await this.clusterCircles.getFeatures(event.pixel);
       if (openClusterFeatures.length) {
-        const feature = openClusterFeatures[0];
-        const members = feature.get('features');
-        const coords = generatePointsCircle(members.length, feature.getGeometry().getCoordinates(),
-          this.map.getView().getResolution());
-        let dist = Infinity;
-        let index;
-        for (let i = 0, ii = coords.length; i < ii; ++i) {
-          const newDist = (event.coordinate[0] - coords[i][0]) ** 2
-            + (event.coordinate[1] - coords[i][1]) ** 2;
-          if (newDist < dist) {
-            index = i;
-            dist = newDist;
-          }
-        }
-        this.openIndicator(members[index]);
-        this.clickedClusterMember = members[index];
+        const clickedClusterMember = getClusterMemberForCoordinate(this.map,
+          openClusterFeatures[0],
+          event.coordinate).feature;
+        this.openIndicator(clickedClusterMember);
+        this.clickedClusterMember = clickedClusterMember;
       } else {
         const features = await this.clusters.getFeatures(event.pixel);
         if (features.length > 0) {
@@ -459,7 +505,7 @@ export default class Cluster {
       geometry: clusterMember.getGeometry(),
     });
     const memberStyle = [circleStyle, iconStyle];
-    if (isSelected && indicatorObject.subAoi) {
+    if (isSelected && indicatorObject.subAoi && indicatorObject.subAoi.length) {
       const subAoiColor = [...asArray(getColor(indicatorObject, this.vm)
         || this.appConfig.branding.primaryColor)];
       // set opacity of rgba color

--- a/app/src/components/map/Cluster.js
+++ b/app/src/components/map/Cluster.js
@@ -234,7 +234,7 @@ export default class Cluster {
       this.map.on('pointermove', this.pointermoveInteraction.bind(this, overlayCallback));
       this.map.on('click', this.clickInteraction);
       const overlay = new Overlay({
-        element: document.getElementById('centerMapOverlay'),
+        element: document.getElementById(`${this.map.get('id')}Overlay`),
         id: 'clusterOverlay',
         offset: [0, -22],
         positioning: 'bottom-center',

--- a/app/src/components/map/Cluster.js
+++ b/app/src/components/map/Cluster.js
@@ -306,10 +306,9 @@ export default class Cluster {
           } else {
             this.openIndicator(features[0].getProperties().features[0]);
           }
-        } else {
-          this.reRender();
         }
       }
+      this.reRender();
     };
   }
 
@@ -460,6 +459,22 @@ export default class Cluster {
       geometry: clusterMember.getGeometry(),
     });
     const memberStyle = [circleStyle, iconStyle];
+    if (isSelected && indicatorObject.subAoi) {
+      const subAoiColor = [...asArray(getColor(indicatorObject, this.vm)
+        || this.appConfig.branding.primaryColor)];
+      // set opacity of rgba color
+      subAoiColor[3] = 0.5;
+      memberStyle.push(new Style({
+        fill: new Fill({
+          color: subAoiColor,
+        }),
+        stroke: new Stroke({
+          color: 'white',
+          width: 1,
+        }),
+        geometry: indicatorObject.subAoi[0].getGeometry(),
+      }));
+    }
     return memberStyle;
   }
 }

--- a/app/src/components/map/formatters.js
+++ b/app/src/components/map/formatters.js
@@ -1,0 +1,61 @@
+
+// eslint-disable-next-line import/prefer-default-export
+export function formatLabel(indicatorObject, vm) {
+  let label = '(coming soon)';
+  if (Object.prototype.hasOwnProperty.call(indicatorObject, 'lastIndicatorValue') || Object.prototype.hasOwnProperty.call(indicatorObject, 'lastMeasurement')) {
+    label = 'Latest value: ';
+    const indVal = indicatorObject.lastIndicatorValue !== '' ? indicatorObject.lastIndicatorValue : indicatorObject.lastMeasurement;
+    if (['E10a1', 'E10a5'].includes(indicatorObject.indicator)) {
+      const percVal = Number((indVal * 100).toPrecision(4));
+      if (percVal > 0) {
+        label += `+${percVal}%`;
+      } else {
+        label += `${percVal}%`;
+      }
+    } else if (['E8'].includes(indicatorObject.indicator)) {
+      label = indVal.toPrecision(3);
+    } else if (['E10a3', 'E10a8', 'E10a9', 'N4c'].includes(indicatorObject.indicator)) {
+      label += 'multiple';
+    } else if (['E10a6', 'E10a7'].includes(indicatorObject.indicator)) {
+      const newIndVal = Number(indicatorObject.lastMeasurement).toPrecision(4);
+      label += `${newIndVal}%`;
+    } else if (['N1', 'N3b', 'N1b', 'E12b', 'C1', 'C2', 'C3', 'E10a10'].includes(indicatorObject.indicator)) {
+      label = '';
+    } else if (indicatorObject.indicator === 'OX') {
+      switch (indicatorObject.lastIndicatorValue) {
+        case 'Red (Low)':
+          label = 'Very low';
+          break;
+        case 'Orange (Low)':
+          label = 'Low';
+          break;
+        case 'Green':
+          label = 'Regular';
+          break;
+        case 'Orange (High)':
+          label = 'High';
+          break;
+        case 'Red (High)':
+          label = 'Very High';
+          break;
+        default:
+          label = '';
+      }
+    } else if (indVal === null) {
+      label = null;
+    } else {
+      label += indVal;
+    }
+  }
+
+  // Overwrite label if archived
+  if (indicatorObject.updateFrequency && indicatorObject.updateFrequency.toLowerCase() === 'archived') {
+    label = 'Archived';
+  }
+  return {
+    city: indicatorObject.city,
+    indicator: vm.baseConfig.indicatorsDefinition[indicatorObject.indicator]
+      .indicatorOverwrite || indicatorObject.description,
+    label,
+  };
+}

--- a/app/src/components/map/map.js
+++ b/app/src/components/map/map.js
@@ -9,7 +9,7 @@ import './olControls.css';
 
 
 class VueMap {
-  constructor() {
+  constructor(id) {
     this.controls = [
       new FullScreen({
         className: 'v-card primary--text ol-full-screen',
@@ -30,6 +30,7 @@ class VueMap {
         enableRotation: false,
       }),
     });
+    this.map.set('id', id);
   }
 }
 const mapRegistry = {};
@@ -43,7 +44,7 @@ const mapRegistry = {};
 export default function getMapInstance(id) {
   const map = mapRegistry[id];
   if (!map) {
-    mapRegistry[id] = new VueMap();
+    mapRegistry[id] = new VueMap(id);
   }
   return mapRegistry[id];
 }

--- a/app/src/store/modules/features.js
+++ b/app/src/store/modules/features.js
@@ -1,7 +1,9 @@
 /* eslint no-shadow: ["error", { "allow": ["state", "getters"] }] */
-import { Wkt } from 'wicket';
+import WKT from 'ol/format/WKT';
 import { latLng } from 'leaflet';
 import countriesJson from '@/assets/countries.json';
+
+const format = new WKT();
 
 let globalIdCounter = 0;
 const state = {
@@ -289,7 +291,6 @@ const actions = {
         });
         // only continue if aoi column is present
         if (Object.prototype.hasOwnProperty.call(data[0], pM.aoi)) {
-          const wkt = new Wkt();
           const featureObjs = {};
           for (let rr = 0; rr < data.length; rr += 1) {
             // Aggregate data based on location
@@ -310,23 +311,17 @@ const actions = {
                   try {
                     // assuming sub-aoi does not change over time
                     if (!['', '/'].includes(data[rr][value])) {
-                      wkt.read(data[rr][value]);
-                      const jsonGeom = wkt.toJson();
-                      // create a feature collection
-                      ftrs = [{
-                        type: 'Feature',
-                        properties: {},
-                        geometry: jsonGeom,
-                      }];
+                      ftrs = [
+                        Object.freeze(format.readFeature(data[rr][value], {
+                          dataProjection: 'EPSG:4326',
+                          featureProjection: 'EPSG:3857',
+                        })),
+                      ];
                     }
                   } catch (err) {
                     console.log(`Error parsing subAoi of locations for index ${rr}`);
                   }
-                  const ftrCol = {
-                    type: 'FeatureCollection',
-                    features: ftrs,
-                  };
-                  featureObjs[uniqueKey][key] = ftrCol;
+                  featureObjs[uniqueKey][key] = ftrs;
                 } else if (key === 'lastMeasurement') {
                   featureObjs[uniqueKey][key] = data[rr][value].length !== 0
                     ? Number(data[rr][value]) : NaN;
@@ -394,7 +389,6 @@ const actions = {
         });
         // only continue if aoi column is present
         if (Object.prototype.hasOwnProperty.call(data[0], pM.aoi)) {
-          const wkt = new Wkt();
           const featureObjs = {};
           for (let rr = 0; rr < data.length; rr += 1) {
             // Aggregate data based on location
@@ -417,14 +411,8 @@ const actions = {
                   try {
                     // assuming sub-aoi does not change over time
                     if (data[rr][value] !== '') {
-                      wkt.read(data[rr][value]);
-                      const jsonGeom = wkt.toJson();
                       // create a feature collection
-                      ftrs = [{
-                        type: 'Feature',
-                        properties: {},
-                        geometry: jsonGeom,
-                      }];
+                      ftrs = [Object.freeze(format.readFeature(data[rr][value]))];
                     }
                   } catch (err) {
                     console.log(`Error parsing subAoi of locations for index ${rr}`);


### PR DESCRIPTION
This PR brings the two missing features "sub-AOI" and "hover overlay" to the center map.

The tooltip overlay behaves slightly different to the current application. In the current application, the tooltip will display the words "Reference Area" when hovering over a sub-AOI. Now it will display the actual information, and placing the tooltip at the position of the indicator poi belonging to the reference area. Please let me know if this change is in your interest.

The subaoi-Geometries are the normal subaois from indicator as seen on the center map of the current applications. Inverse Polygons (as seen on indicator maps) are not yet implemented.

This PR changes the WKT-parsing to ol geometries. This will temporarily break some indicator maps.

Features from https://github.com/eurodatacube/eodash/issues/1173:
 - show tooltip on hover with indicator info
 - show subaoi multipolygon (with 50% opacity)