### PR TITLE
feat: modularize time selection component

### DIFF
--- a/app/src/components/CustomDashboardGrid.vue
+++ b/app/src/components/CustomDashboardGrid.vue
@@ -98,10 +98,11 @@
                 @ready="onMapReady(element.poi)"
               />
               <indicator-data
-                style="top: 0px; position: absolute;"
                 v-else
-                class="pa-5 chart"
+                disableAutoFocus
                 :currentIndicator="element.indicatorObject"
+                class="pa-5 chart"
+                style="top: 0px; position: absolute;"
               />
             </div>
             <template

--- a/app/src/components/IndicatorData.vue
+++ b/app/src/components/IndicatorData.vue
@@ -38,35 +38,15 @@
         :src="require('@/assets/E10a8_label.jpg')" alt="color legend"
         style="position: absolute; width: 150px; z-index: 0;
         top: 0px; right: 0px;"/>
-      <v-row
-        class="justify-center align-center timeSelection mr-6 ml-0"
-        style="position: absolute; bottom: 0px; z-index: 1000;
-          width: auto; max-width: 100%;left:-45px;"
-      >
-        <v-col cols="6">
-          <v-select
-            outlined dense autofocus hide-details
-            :prepend-inner-icon="(arrayOfObjects && dataLayerTime) && (arrayOfObjects
-              .map((i) => i.value)
-              .indexOf(dataLayerTime) > 0
-                ? 'mdi-arrow-left-drop-circle'
-                : 'mdi-asterisk')"
-            :append-icon="(arrayOfObjects && dataLayerTime) && (arrayOfObjects
-              .map((i) => i.value)
-              .indexOf(dataLayerTime) < arrayOfObjects.length - 1
-                ? 'mdi-arrow-right-drop-circle'
-                : 'mdi-asterisk')"
-            menu-props="auto"
-            :items="arrayOfObjects"
-            item-value="value"
-            item-text="name"
-            v-model="dataLayerTime"
-            @change="dataLayerTimeSelection"
-            @click:prepend-inner="dataLayerReduce"
-            @click:append="dataLayerIncrease">
-          </v-select>
-        </v-col>
-      </v-row>
+      <div style="position: absolute; width: 100%; max-width: 180px; left: 75px; bottom: -10px">
+        <indicator-time-selection
+          v-if="dataLayerTime"
+          :autofocus="!disableAutoFocus"
+          :available-values="arrayOfObjects"
+          :original-time.sync="dataLayerTime"
+          :enable-compare="false"
+        />
+      </div>
   </div>
   <div style="width: 100%; height: 100%;" v-else>
     <line-chart v-if='lineChartIndicators.includes(indicatorObject.indicator)'
@@ -99,19 +79,22 @@ import LineChart from '@/components/LineChart.vue';
 import MapChart from '@/components/MapChart.vue';
 import NUTS from '@/assets/NUTS_RG_03M_2016_4326_ESL2-DEL3.json';
 
+import IndicatorTimeSelection from './IndicatorTimeSelection.vue';
+
 export default {
-  props: [
-    'currentIndicator',
-  ],
+  props: {
+    currentIndicator: Object,
+    disableAutoFocus: Boolean,
+  },
   components: {
     BarChart,
     LineChart,
     MapChart,
+    IndicatorTimeSelection,
   },
   data() {
     return {
       dataLayerTime: null,
-      dataLayerIndex: 0,
       lineChartIndicators: [
         'E12', 'E12b', 'E8', 'N1b', 'N1', 'N3', 'N3b',
         'GG', 'E10a', 'E10a9', 'CV', 'OW', 'E10c', 'E10a10', 'OX',
@@ -139,7 +122,11 @@ export default {
 
   mounted() {
     const d = this.indicatorObject.time[this.indicatorObject.time.length - 1];
-    this.dataLayerTime = d.toFormat('dd. MMM');
+    const formatted = d.toFormat('dd. MMM');
+    this.dataLayerTime = {
+      value: formatted,
+      name: formatted,
+    };
   },
   computed: {
     ...mapState('config', ['appConfig', 'baseConfig']),
@@ -804,8 +791,8 @@ export default {
 
           const filteredFeatures = features.filter((d) => {
             let include = false;
-            if (d.time instanceof DateTime) {
-              include = d.time.toFormat('dd. MMM') === this.dataLayerTime
+            if (d.time instanceof DateTime && this.dataLayerTime) {
+              include = d.time.toFormat('dd. MMM') === this.dataLayerTime.value
                 && !Number.isNaN(d.value);
             }
             return include;
@@ -874,27 +861,6 @@ export default {
     resetBCZoom() {
       this.extentChanged(false);
       this.$refs.barChart._data._chart.resetZoom();
-    },
-    dataLayerTimeSelection(payload) {
-      this.dataLayerTime = payload;
-      const newIndex = this.arrayOfObjects
-        .map((i) => i.value)
-        .indexOf(this.dataLayerTime);
-      this.dataLayerIndex = newIndex;
-    },
-    dataLayerReduce() {
-      const currentIndex = this.arrayOfObjects
-        .map((i) => i.value)
-        .indexOf(this.dataLayerTime);
-      this.dataLayerIndex = currentIndex - 1;
-      this.dataLayerTimeSelection(this.arrayOfObjects[currentIndex - 1].value);
-    },
-    dataLayerIncrease() {
-      const currentIndex = this.arrayOfObjects
-        .map((i) => i.value)
-        .indexOf(this.dataLayerTime);
-      this.dataLayerIndex = currentIndex + 1;
-      this.dataLayerTimeSelection(this.arrayOfObjects[currentIndex + 1].value);
     },
     formatNumRef(num, maxDecimals = 3) {
       return Number.parseFloat(num.toFixed(maxDecimals));
@@ -1362,8 +1328,5 @@ export default {
 <style lang="scss" scoped>
 .md-body {
   font-size: small;
-}
-::v-deep .mdi-asterisk {
-  visibility: hidden;
 }
 </style>

--- a/app/src/components/IndicatorMap.vue
+++ b/app/src/components/IndicatorMap.vue
@@ -1765,9 +1765,6 @@ export default {
 ::v-deep .leaflet-control-layers-toggle {
   background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="%23003247" width="32px" height="32px"><path d="M0 0h24v24H0z" fill="none"/><path d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z"/></svg>');
 }
-::v-deep .mdi-asterisk {
-  visibility: hidden;
-}
 ::v-deep .leaflet-bar a, ::v-deep .leaflet-control-attribution {
   color: var(--v-primary-base) !important;
 }

--- a/app/src/components/IndicatorMap.vue
+++ b/app/src/components/IndicatorMap.vue
@@ -91,7 +91,7 @@
       :optionsStyle="subAoiInverseStyle"
       >
       </l-geo-json>
-      <l-layer-group ref="dataLayers">
+      <l-layer-group ref="dataLayers" v-if="dataLayerTime">
         <l-geo-json
         :geojson="indicator.subAoi"
         :pane="tooltipPane"
@@ -178,7 +178,7 @@
           </LWMSTileLayer>
         </template>
       </l-layer-group>
-      <l-layer-group ref="compareLayers">
+      <l-layer-group ref="compareLayers" v-if="compareLayerTime">
         <!-- XYZ grouping is not implemented yet -->
         <LTileLayer
         v-for="(layerConfig, i) in mergedConfigsCompare.filter(l => l.protocol === 'xyz')"
@@ -358,96 +358,17 @@
           background: rgba(255, 255, 255, 0.6); font-size: 16px; pointer-events: none;">
             {{indicator.compareDisplay.mapLabel}}
         </h3>
-        <v-sheet
+        <indicator-time-selection
           v-if="!mergedConfigsData[0].disableTimeSelection"
-          class="row justify-center align-center"
-          style="position: absolute; bottom: 30px; z-index: 1000; width: auto; max-width: 100%;"
-        >
-          <v-col
-            v-if="enableCompare && !indicator.compareDisplay"
-            cols="6"
-            class="pr-0"
-          >
-            <v-select
-              v-if="enableCompare"
-              outlined
-              dense
-              :autofocus="!disableAutoFocus"
-              attach
-              hide-details
-              :prepend-inner-icon="(arrayOfObjects && compareLayerTime) && (arrayOfObjects
-                .map((i) => i.value)
-                .indexOf(compareLayerTime.value) > 0
-                  ? 'mdi-arrow-left-drop-circle'
-                  : 'mdi-asterisk')"
-              :append-icon="(arrayOfObjects && compareLayerTime) && (arrayOfObjects
-                .map((i) => i.value)
-                .indexOf(compareLayerTime.value) < arrayOfObjects.length - 1
-                  ? 'mdi-arrow-right-drop-circle'
-                  : 'mdi-asterisk')"
-              menu-props="auto"
-              :items="arrayOfObjects"
-              item-value="value"
-              item-text="name"
-              return-object
-              v-model="compareLayerTime"
-              @focus="focusSelect(true)"
-              @blur="focusSelect(false)"
-              @change="compareLayerTimeSelection"
-              @click:prepend-inner="compareLayerReduce"
-              @click:append="compareLayerIncrease"
-            ></v-select>
-          </v-col>
-          <v-col
-            :cols="enableCompare && !indicator.compareDisplay ? 6 : 12"
-          >
-            <v-select
-              outlined
-              dense
-              :autofocus="!disableAutoFocus"
-              attach
-              hide-details
-              :prepend-inner-icon="(arrayOfObjects && dataLayerTime) && (arrayOfObjects
-                .map((i) => i.value)
-                .indexOf(dataLayerTime.value) > 0
-                  ? 'mdi-arrow-left-drop-circle'
-                  : 'mdi-asterisk')"
-              :append-icon="(arrayOfObjects && dataLayerTime) && (arrayOfObjects
-                .map((i) => i.value)
-                .indexOf(dataLayerTime.value) < arrayOfObjects.length - 1
-                  ? 'mdi-arrow-right-drop-circle'
-                  : 'mdi-asterisk')"
-              menu-props="auto"
-              :items="arrayOfObjects"
-              item-value="value"
-              item-text="name"
-              return-object
-              v-model="dataLayerTime"
-              @focus="focusSelect(true)"
-              @blur="focusSelect(false)"
-              @change="dataLayerTimeSelection"
-              @click:prepend-inner="dataLayerReduce"
-              @click:append="dataLayerIncrease"
-            >
-              <template v-slot:prepend
-              v-if="!mergedConfigsData[0].disableCompare">
-                <v-tooltip
-                  bottom
-                >
-                  <template v-slot:activator="{ on }">
-                    <v-icon
-                      v-on="on"
-                      @click="enableCompare = !enableCompare"
-                    >
-                      mdi-compare
-                    </v-icon>
-                  </template>
-                  Compare two images
-                </v-tooltip>
-              </template>
-            </v-select>
-          </v-col>
-        </v-sheet>
+          :autofocus="!disableAutoFocus"
+          :available-values="arrayOfObjects"
+          :indicator="indicator"
+          :compare-active.sync="enableCompare"
+          :compare-time.sync="compareLayerTime"
+          :original-time.sync="dataLayerTime"
+          :enable-compare="!mergedConfigsData[0].disableCompare"
+          @focusSelect="focusSelect"
+        />
       </div>
       <l-control-attribution position="bottomright" prefix=''></l-control-attribution>
       <l-control-layers position="topright" ref="layersControl"></l-control-layers>
@@ -488,6 +409,7 @@ import turfDifference from '@turf/difference';
 import countries from '@/assets/countries.json';
 import gsaFile from '@/assets/gsa_data.json';
 
+import IndicatorTimeSelection from './IndicatorTimeSelection.vue';
 
 const emptyF = {
   type: 'FeatureCollection',
@@ -528,6 +450,7 @@ export default {
     LControl,
     LTooltip,
     'l-marker-cluster': Vue2LeafletMarkerCluster,
+    IndicatorTimeSelection,
   },
   data() {
     return {
@@ -558,8 +481,6 @@ export default {
       },
       dataLayerTime: null,
       compareLayerTime: null,
-      dataLayerIndex: 0,
-      compareLayerIndex: 0,
       dataFeaturesCount: 0,
       compareFeaturesCount: 0,
       selectedCountry: null,
@@ -846,10 +767,8 @@ export default {
     },
   },
   mounted() {
-    this.dataLayerIndex = this.usedTimes.time.length - 1;
-
     if (!this.dataLayerTimeProp) {
-      this.dataLayerTime = { value: this.usedTimes.time[this.dataLayerIndex] };
+      this.dataLayerTime = { value: this.usedTimes.time[this.usedTimes.time.length - 1] };
     }
 
     if (!this.compareLayerTimeProp) {
@@ -1100,7 +1019,9 @@ export default {
       };
     },
     getColorCode(side) {
-      const i = side === 'compare' ? this.compareLayerIndex : this.dataLayerIndex;
+      const i = side === 'compare'
+        ? this.arrayOfObjects.findIndex((o) => o.value === this.compareLayerTime.value)
+        : this.arrayOfObjects.findIndex((o) => o.value === this.dataLayerTime.value);
       let currentValue = null;
       // compensate for color code with only one entry, still showing it
       if (this.usedTimes.colorCode) {
@@ -1130,7 +1051,9 @@ export default {
       };
     },
     configFromInputData(side) {
-      const i = side === 'compare' ? this.compareLayerIndex : this.dataLayerIndex;
+      const i = side === 'compare'
+        ? this.arrayOfObjects.findIndex((o) => o.value === this.compareLayerTime.value)
+        : this.arrayOfObjects.findIndex((o) => o.value === this.dataLayerTime.value);
       const inputData = this.usedTimes.inputData.length === 1
         ? this.usedTimes.inputData[0]
         : this.usedTimes.inputData[i];
@@ -1325,17 +1248,8 @@ export default {
       });
       return additionalSettings;
     },
-    dataLayerTimeSelection(payload) {
-      // Different object returned either by arrow use or by dropdown use
-      if (Array.isArray(payload) || !(payload.value)) {
-        this.dataLayerTime = { value: payload, name: `${payload}` };
-      } else {
-        this.dataLayerTime = payload;
-      }
-      const newIndex = this.arrayOfObjects
-        .map((i) => i.value)
-        .indexOf(this.dataLayerTime.value ? this.dataLayerTime.value : this.dataLayerTime);
-      this.dataLayerIndex = newIndex;
+    dataLayerTimeSelection(timeObj) {
+      this.dataLayerTime = timeObj;
       this.refreshLayers('data');
       this.$nextTick(() => {
         this.slider.setRightLayers(
@@ -1345,7 +1259,6 @@ export default {
       if (this.indicator.compareDisplay) {
         // shared time on both sides in case of compareDisplay being set
         this.compareLayerTime = this.dataLayerTime;
-        this.compareLayerIndex = newIndex;
         this.refreshLayers('compare');
         this.$nextTick(() => {
           this.slider.setLeftLayers(
@@ -1366,17 +1279,8 @@ export default {
       }
       return actualLayers;
     },
-    compareLayerTimeSelection(payload) {
-      // Different object returned either by arrow use or by dropdown use
-      if (Array.isArray(payload) || !(payload.value)) {
-        this.compareLayerTime = { value: payload, name: `${payload}` };
-      } else {
-        this.compareLayerTime = payload;
-      }
-      const newIndex = this.arrayOfObjects
-        .map((i) => i.value)
-        .indexOf(this.compareLayerTime.value ? this.compareLayerTime.value : this.compareLayerTime);
-      this.compareLayerIndex = newIndex;
+    compareLayerTimeSelection(timeObj) {
+      this.compareLayerTime = timeObj;
       this.refreshLayers('compare');
       this.$nextTick(() => {
         this.slider.setLeftLayers(
@@ -1385,34 +1289,6 @@ export default {
       });
 
       this.compareLayerTimeUpdated(this.compareLayerTime.name);
-    },
-    dataLayerReduce() {
-      const currentIndex = this.arrayOfObjects
-        .map((i) => i.value)
-        .indexOf(this.dataLayerTime.value ? this.dataLayerTime.value : this.dataLayerTime);
-      this.dataLayerIndex = currentIndex - 1;
-      this.dataLayerTimeSelection(this.arrayOfObjects[currentIndex - 1]);
-    },
-    dataLayerIncrease() {
-      const currentIndex = this.arrayOfObjects
-        .map((i) => i.value)
-        .indexOf(this.dataLayerTime.value ? this.dataLayerTime.value : this.dataLayerTime);
-      this.dataLayerIndex = currentIndex + 1;
-      this.dataLayerTimeSelection(this.arrayOfObjects[currentIndex + 1]);
-    },
-    compareLayerReduce() {
-      const currentIndex = this.arrayOfObjects
-        .map((i) => i.value)
-        .indexOf(this.compareLayerTime.value ? this.compareLayerTime.value : this.compareLayerTime);
-      this.compareLayerIndex = currentIndex - 1;
-      this.compareLayerTimeSelection(this.arrayOfObjects[currentIndex - 1]);
-    },
-    compareLayerIncrease() {
-      const currentIndex = this.arrayOfObjects
-        .map((i) => i.value)
-        .indexOf(this.compareLayerTime.value ? this.compareLayerTime.value : this.compareLayerTime);
-      this.compareLayerIndex = currentIndex + 1;
-      this.compareLayerTimeSelection(this.arrayOfObjects[currentIndex + 1]);
     },
     getInitialCompareTime() {
       // find closest entry one year before latest time
@@ -1786,6 +1662,12 @@ export default {
       handler(v) {
         if (v) this.center = v;
       },
+    },
+    dataLayerTime(timeObj) {
+      this.dataLayerTimeSelection(timeObj);
+    },
+    compareLayerTime(timeObj) {
+      this.compareLayerTimeSelection(timeObj);
     },
     dataLayerTimeProp: {
       immediate: true,

--- a/app/src/components/IndicatorMap.vue
+++ b/app/src/components/IndicatorMap.vue
@@ -1804,8 +1804,4 @@ export default {
 ::v-deep .leaflet-top.leaflet-right {
   margin-top: 45px;
 }
-
-::v-deep .v-menu__content {
-  transform: translate(1%, -87%);
-}
 </style>

--- a/app/src/components/IndicatorMap.vue
+++ b/app/src/components/IndicatorMap.vue
@@ -1019,9 +1019,7 @@ export default {
       };
     },
     getColorCode(side) {
-      const i = side === 'compare'
-        ? this.arrayOfObjects.findIndex((o) => o.value === this.compareLayerTime.value)
-        : this.arrayOfObjects.findIndex((o) => o.value === this.dataLayerTime.value);
+      const i = this.getCurrentIndex(side);
       let currentValue = null;
       // compensate for color code with only one entry, still showing it
       if (this.usedTimes.colorCode) {
@@ -1040,6 +1038,11 @@ export default {
         ? this.getIndicatorColor(currentValue)
         : this.appConfig.branding.primaryColor;
     },
+    getCurrentIndex(side) {
+      return side === 'compare'
+        ? this.arrayOfObjects.findIndex((o) => o.value === this.compareLayerTime.value)
+        : this.arrayOfObjects.findIndex((o) => o.value === this.dataLayerTime.value);
+    },
     subAoiStyle(side) {
       const currentValue = this.getColorCode(side);
       return {
@@ -1051,9 +1054,7 @@ export default {
       };
     },
     configFromInputData(side) {
-      const i = side === 'compare'
-        ? this.arrayOfObjects.findIndex((o) => o.value === this.compareLayerTime.value)
-        : this.arrayOfObjects.findIndex((o) => o.value === this.dataLayerTime.value);
+      const i = this.getCurrentIndex(side);
       const inputData = this.usedTimes.inputData.length === 1
         ? this.usedTimes.inputData[0]
         : this.usedTimes.inputData[i];

--- a/app/src/components/IndicatorTimeSelection.vue
+++ b/app/src/components/IndicatorTimeSelection.vue
@@ -17,13 +17,11 @@
         attach
         hide-details
         :prepend-inner-icon="(availableValues && compareTime) && (availableValues
-          .map((i) => i.value)
-          .indexOf(compareTime.value) > 0
+          .findIndex((i) => i.value === compareTime.value) > 0
             ? 'mdi-arrow-left-drop-circle'
             : 'mdi-asterisk')"
         :append-icon="(availableValues && compareTime) && (availableValues
-          .map((i) => i.value)
-          .indexOf(compareTime.value) < availableValues.length - 1
+          .findIndex((i) => i.value === compareTime.value) < availableValues.length - 1
             ? 'mdi-arrow-right-drop-circle'
             : 'mdi-asterisk')"
         menu-props="auto"
@@ -49,13 +47,11 @@
         attach
         hide-details
         :prepend-inner-icon="(availableValues && originalTime) && (availableValues
-          .map((i) => i.value)
-          .indexOf(originalTime.value) > 0
+          .findIndex((v) => v.value === originalTime.value) > 0
             ? 'mdi-arrow-left-drop-circle'
             : 'mdi-asterisk')"
         :append-icon="(availableValues && originalTime) && (availableValues
-          .map((i) => i.value)
-          .indexOf(originalTime.value) < availableValues.length - 1
+          .findIndex((i) => i.value === originalTime.value) < availableValues.length - 1
             ? 'mdi-arrow-right-drop-circle'
             : 'mdi-asterisk')"
         menu-props="auto"

--- a/app/src/components/IndicatorTimeSelection.vue
+++ b/app/src/components/IndicatorTimeSelection.vue
@@ -164,3 +164,9 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+::v-deep .mdi-asterisk {
+  visibility: hidden;
+}
+</style>

--- a/app/src/components/IndicatorTimeSelection.vue
+++ b/app/src/components/IndicatorTimeSelection.vue
@@ -4,7 +4,7 @@
     style="position: absolute; bottom: 30px; z-index: 1000; width: auto; max-width: 100%;"
   >
     <v-col
-      v-if="compareActive && !indicator.compareDisplay"
+      v-if="currentlyComparing"
       cols="6"
       class="pr-0"
     >
@@ -37,7 +37,7 @@
       ></v-select>
     </v-col>
     <v-col
-      :cols="compareActive && !indicator.compareDisplay ? 6 : 12"
+      :cols="currentlyComparing ? 6 : 12"
     >
       <v-select
         ref="originalTimeSelect"
@@ -114,13 +114,21 @@ export default {
     },
     indicator: {
       type: Object,
-      required: true,
     },
   },
   data: () => ({
     compareTimeModel: null,
     originalTimeModel: null,
   }),
+  computed: {
+    currentlyComparing() {
+      let pass = true;
+      if (this.indicator) {
+        pass = !this.indicator.compareDisplay;
+      }
+      return this.compareActive && pass;
+    },
+  },
   created() {
     this.compareTimeModel = this.compareTime;
     this.originalTimeModel = this.originalTime;
@@ -164,5 +172,8 @@ export default {
 <style scoped>
 ::v-deep .mdi-asterisk {
   visibility: hidden;
+}
+::v-deep .v-menu__content {
+  transform: translate(1%, -87%);
 }
 </style>

--- a/app/src/components/IndicatorTimeSelection.vue
+++ b/app/src/components/IndicatorTimeSelection.vue
@@ -1,0 +1,166 @@
+<template>
+  <v-sheet
+    class="row justify-center align-center"
+    style="position: absolute; bottom: 30px; z-index: 1000; width: auto; max-width: 100%;"
+  >
+    <v-col
+      v-if="compareActive && !indicator.compareDisplay"
+      cols="6"
+      class="pr-0"
+    >
+      <v-select
+        ref="compareTimeSelect"
+        v-if="compareActive"
+        outlined
+        dense
+        :autofocus="autofocus"
+        attach
+        hide-details
+        :prepend-inner-icon="(availableValues && compareTime) && (availableValues
+          .map((i) => i.value)
+          .indexOf(compareTime.value) > 0
+            ? 'mdi-arrow-left-drop-circle'
+            : 'mdi-asterisk')"
+        :append-icon="(availableValues && compareTime) && (availableValues
+          .map((i) => i.value)
+          .indexOf(compareTime.value) < availableValues.length - 1
+            ? 'mdi-arrow-right-drop-circle'
+            : 'mdi-asterisk')"
+        menu-props="auto"
+        :items="availableValues"
+        item-value="value"
+        item-text="name"
+        return-object
+        v-model="compareTimeModel"
+        @focus="() => $emit('focusSelect', true)"
+        @blur="() => $emit('focusSelect', false)"
+        @click:prepend-inner="change('compareTimeModel', -1)"
+        @click:append="change('compareTimeModel', +1)"
+      ></v-select>
+    </v-col>
+    <v-col
+      :cols="compareActive && !indicator.compareDisplay ? 6 : 12"
+    >
+      <v-select
+        ref="originalTimeSelect"
+        outlined
+        dense
+        :autofocus="autofocus"
+        attach
+        hide-details
+        :prepend-inner-icon="(availableValues && originalTime) && (availableValues
+          .map((i) => i.value)
+          .indexOf(originalTime.value) > 0
+            ? 'mdi-arrow-left-drop-circle'
+            : 'mdi-asterisk')"
+        :append-icon="(availableValues && originalTime) && (availableValues
+          .map((i) => i.value)
+          .indexOf(originalTime.value) < availableValues.length - 1
+            ? 'mdi-arrow-right-drop-circle'
+            : 'mdi-asterisk')"
+        menu-props="auto"
+        :items="availableValues"
+        item-value="value"
+        item-text="name"
+        return-object
+        v-model="originalTimeModel"
+        @focus="() => $emit('focusSelect', true)"
+        @blur="() => $emit('focusSelect', false)"
+        @click:prepend-inner="change('originalTimeModel', -1)"
+        @click:append="change('originalTimeModel', +1)"
+      >
+        <template v-slot:prepend
+        v-if="enableCompare">
+          <v-tooltip
+            bottom
+          >
+            <template v-slot:activator="{ on }">
+              <v-icon
+                v-on="on"
+                @click="() => $emit('update:compareActive', !compareActive)"
+              >
+                mdi-compare
+              </v-icon>
+            </template>
+            Compare two images
+          </v-tooltip>
+        </template>
+      </v-select>
+    </v-col>
+  </v-sheet>
+</template>
+
+<script>
+export default {
+  props: {
+    autofocus: {
+      type: Boolean,
+      default: true,
+    },
+    availableValues: {
+      type: Array,
+      required: true,
+    },
+    compareActive: {
+      type: Boolean,
+      default: false,
+    },
+    compareTime: {
+      type: Object,
+    },
+    originalTime: {
+      type: Object,
+      required: true,
+    },
+    enableCompare: {
+      type: Boolean,
+      default: true,
+    },
+    indicator: {
+      type: Object,
+      required: true,
+    },
+  },
+  data: () => ({
+    compareTimeModel: null,
+    originalTimeModel: null,
+  }),
+  created() {
+    this.compareTimeModel = this.compareTime;
+    this.originalTimeModel = this.originalTime;
+  },
+  methods: {
+    change(modelName, adjust) {
+      const newIndex = this.availableValues
+        .findIndex((i) => i.value === this[modelName].value) + adjust;
+      this[modelName] = this.availableValues[newIndex];
+    },
+  },
+  watch: {
+    compareTime: {
+      deep: true,
+      handler(timeObj) {
+        this.compareTimeModel = timeObj;
+      },
+    },
+    originalTime: {
+      deep: true,
+      handler(timeObj) {
+        this.originalTimeModel = timeObj;
+      },
+    },
+    compareTimeModel: {
+      deep: true,
+      handler(timeObj) {
+        this.$emit('update:compareTime', timeObj);
+      },
+    },
+    originalTimeModel: {
+      deep: true,
+      handler(timeObj) {
+        this.$emit('update:originalTime', timeObj);
+      },
+    },
+  },
+};
+</script>


### PR DESCRIPTION
This PR aims to extract the time selection feature into its own component, while at the same tame reducing a bit the size of `IndicatorMap.vue`.

Todo:

- [x] Update IndicatorChart map-chart to use new component
- [ ] ~~Consider moving the complex time parsing logic to component?~~ Currently it is too different for IndicatorMap and IndicatorData

Closes #1317 