### PR TITLE
Improve image display

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -11703,6 +11703,11 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
+    "medium-zoom": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.0.6.tgz",
+      "integrity": "sha512-UdiUWfvz9fZMg1pzf4dcuqA0W079o0mpqbTnOz5ip4VGYX96QjmbM+OgOU/0uOzAytxC0Ny4z+VcYQnhdifimg=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -29,6 +29,7 @@
     "leaflet-side-by-side": "github:lubojr/leaflet-side-by-side#85dc573d0a27d2ffce91562fe27072c35d7e3e32",
     "luxon": "^1.24.1",
     "marked": "^4.0.10",
+    "medium-zoom": "^1.0.6",
     "register-service-worker": "^1.7.1",
     "socket.io-client": "^4.0.0",
     "vue": "^2.6.11",

--- a/app/src/components/CustomDashboardGrid.vue
+++ b/app/src/components/CustomDashboardGrid.vue
@@ -375,11 +375,14 @@
 
 <script>
 import { DateTime } from 'luxon';
+import mediumZoom from 'medium-zoom';
 import IndicatorData from '@/components/IndicatorData.vue';
 import IndicatorMap from '@/components/IndicatorMap.vue';
 import LoadingAnimation from '@/components/LoadingAnimation.vue';
 import { loadIndicatorData } from '@/utils';
 import { mapGetters, mapState, mapActions } from 'vuex';
+
+const zoom = mediumZoom();
 
 export default {
   props: {
@@ -547,7 +550,19 @@ export default {
       );
     },
     convertToMarkdown(text) {
+      // each time markdown is rendered, register its images for the zoom feature
+      this.registerImageZoom();
       return this.$marked(text);
+    },
+    registerImageZoom() {
+      this.$nextTick(() => {
+        // detach all previously attached images
+        zoom.detach();
+        // attach all images in .textAreas
+        zoom.attach(document.querySelectorAll('.textArea img'), {
+          background: 'var(--v-background-base)',
+        });
+      });
     },
     async performChange(method, params) {
       this.$emit('change');
@@ -677,5 +692,15 @@ export default {
 ::v-deep .v-navigation-drawer--close {
   visibility: visible;
   transform: translateY(60%) !important;
+}
+</style>
+
+<style>
+.medium-zoom-overlay {
+  z-index: 1;
+  opacity: .8 !important;
+}
+.medium-zoom-image--opened {
+  z-index: 2;
 }
 </style>

--- a/app/src/components/CustomDashboardGrid.vue
+++ b/app/src/components/CustomDashboardGrid.vue
@@ -676,15 +676,26 @@ export default {
 .chart {
   background: #fff;
 }
-::v-deep .textArea img, ::v-deep .textArea video, ::v-deep .textArea iframe {
-  max-width: 100%;
-}
 .elementCard {
   overflow: hidden;
 }
 .textAreaContainer {
   overflow-y: auto;
+}
+.textAreaContainer,
+.textArea {
   height: 100%;
+}
+::v-deep .textArea img,
+::v-deep .textArea video,
+::v-deep .textArea iframe {
+  max-width: 100%;
+}
+::v-deep .textArea p:only-child,
+::v-deep .textArea p:only-child img:only-child,
+::v-deep .textArea p:only-child video:only-child,
+::v-deep .textArea p:only-child iframe:only-child {
+  max-height: 100%;
 }
 ::v-deep .v-navigation-drawer--open {
   transform: translateY(0%) !important;
@@ -695,7 +706,7 @@ export default {
 }
 </style>
 
-<style>
+<style lang="scss">
 .medium-zoom-overlay {
   z-index: 1;
   opacity: .8 !important;


### PR DESCRIPTION
This PR adds the medium-zoom pacakge to enable automatic zoom highlighting of images in a custom dashboard text element.

It also uses the nice `:only-child` pseudoselector to check if there is only one image/video/iframe in the text block and apply 100% max-height to it.

Closes #1325