### PR TITLE
[WIP] Ol indicator map

### DIFF
--- a/app/src/components/IndicatorMap.vue
+++ b/app/src/components/IndicatorMap.vue
@@ -223,6 +223,20 @@ export default {
         ...this.mergedConfigsData[0],
       };
     },
+    minZoom() {
+      if (this.subAoi || this.aoi) {
+        if (this.mergedConfigsData[0].largeSubAoi) {
+          return 2;
+        } if (this.mergedConfigsData[0].midSubAoi) {
+          return 9;
+        }
+        if ((!this.subAoi.features || !this.subAoi.features.length)) {
+          return 0;
+        }
+        return 13;
+      }
+      return this.mapDefaults.minMapZoom;
+    },
     countrySelection() {
       return this.mergedConfigsData[0].countrySelection;
     },

--- a/app/src/components/map/Cluster.js
+++ b/app/src/components/map/Cluster.js
@@ -16,8 +16,13 @@ import VectorSource from 'ol/source/Vector';
 import { asArray } from 'ol/color';
 import { Feature, Overlay } from 'ol';
 import { fromLonLat } from 'ol/proj';
+import GeoJSON from 'ol/format/GeoJSON';
 import { getColor } from './olMapColors';
 import { indicatorClassesIcons } from '../../config/trilateral';
+
+const geoJsonFormat = new GeoJSON({
+  featureProjection: 'EPSG:3857',
+});
 
 const circleDistanceMultiplier = 1;
 const circleFootSeparation = 28;
@@ -421,8 +426,8 @@ export default class Cluster {
       // display subaoi of selected indicator, also when cluster is collapsed
       if (selectedIndicatorFeature) {
         const selectedIndicatorObject = selectedIndicatorFeature.get('properties').indicatorObject;
-        if (selectedIndicatorObject.subAoi && selectedIndicatorObject.subAoi.length) {
-          styles.push(this.getStyleForSubaoi(selectedIndicatorObject));
+        if (selectedIndicatorObject.subAoi) {
+          styles.push(this.getStyleForSubaoi(selectedIndicatorObject, selectedIndicatorFeature));
         }
       }
       return styles;
@@ -517,17 +522,23 @@ export default class Cluster {
       geometry: clusterMember.getGeometry(),
     });
     const memberStyle = [circleStyle, iconStyle];
-    if (isSelected && indicatorObject.subAoi && indicatorObject.subAoi.length) {
-      memberStyle.push(this.getStyleForSubaoi(indicatorObject));
+    if (isSelected && indicatorObject.subAoi) {
+      memberStyle.push(this.getStyleForSubaoi(indicatorObject, clusterMember));
     }
     return memberStyle;
   }
 
   /**
    * @param {*} indicatorObject indicator object containing the subaoi
+   * @param {*} subAoiGeom ol geometry of subAoi
    * @returns {*} SubAOI Style
    */
-  getStyleForSubaoi(indicatorObject) {
+  getStyleForSubaoi(indicatorObject, indicatorFeature) {
+    // pre-calculate geometry once to avoid unnecessary computation in style function
+    if (!indicatorFeature.get('olSubAoiGeom')) {
+      indicatorFeature.set('olSubAoiGeom', geoJsonFormat
+        .readGeometry(indicatorObject.subAoi.features[0].geometry));
+    }
     const subAoiColor = [...asArray(getColor(indicatorObject, this.vm)
         || this.vm.appConfig.branding.primaryColor)];
       // set opacity of rgba color
@@ -540,7 +551,7 @@ export default class Cluster {
         color: 'white',
         width: 1,
       }),
-      geometry: indicatorObject.subAoi[0].getGeometry(),
+      geometry: indicatorFeature.get('olSubAoiGeom'),
     });
   }
 }

--- a/app/src/components/map/DataMap.vue
+++ b/app/src/components/map/DataMap.vue
@@ -1,0 +1,148 @@
+<template>
+  <div ref="mapContainer" style="height: 100%; width: 100%; background: #cad2d3; z-index: 1">
+    <LayerControl
+      v-if="loaded"
+      :mapId="mapId"
+      :baseLayers="baseLayers"
+      :overlayConfigs="overlayConfigs"
+    />
+  </div>
+</template>
+
+<script>
+import {
+  mapGetters,
+  mapState,
+} from 'vuex';
+import LayerControl from '@/components/map/LayerControl.vue';
+import { createLayerFromConfig } from '@/components/map/layers';
+import getMapInstance from '@/components/map/map';
+import { formatLabel } from '@/components/map/formatters';
+import LayerGroup from 'ol/layer/Group';
+
+
+export default {
+  components: {
+    LayerControl,
+  },
+  props: {
+    currentIndicator: String,
+    /**
+     * to do: define control management via options
+     * @property {boolean} attributionControl
+     * @property {boolean} zoomControl
+     */
+    options: Object,
+    overlayConfigs: Array,
+    baseLayers: Array,
+    mapId: String,
+    zoomExtent: Array,
+    constrainExtent: Array,
+    minZoom: Number,
+  },
+  data() {
+    return {
+      map: null,
+      loaded: false,
+      defaultMapOptions: {
+        attributionControl: false,
+        zoomControl: false,
+      },
+      opacityTerrain: [1],
+      opacityOverlay: [0, 0, 0, 0, 0, 0, 0.4, 0.4, 0.8, 0.8, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9],
+      opacityCountries: [1, 1, 1, 1, 0.7, 0.7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    };
+  },
+  watch: {
+    getGroupedFeatures(value) {
+      if (value.length) {
+        this.initMap();
+      }
+    },
+  },
+  computed: {
+    ...mapGetters('features', ['getGroupedFeatures']),
+    ...mapState('config', ['appConfig', 'baseConfig']),
+    countriesJson() {
+      return countries;
+    },
+    indicatorsDefinition: () => this.baseConfig.indicatorsDefinition,
+  },
+  mounted() {
+    this.initMap();
+    const { map } = getMapInstance(this.mapId);
+    if (this.minZoom !== undefined) {
+      map.getView().setMinZoom(this.minZoom);
+    }
+    map.setTarget(/** @type {HTMLElement} */ (this.$refs.mapContainer));
+    if (this.zoomExtent) {
+      map.getView().fit(this.zoomExtent, {
+        padding: [30, 30, 30, 30],
+      });
+    }
+    this.$emit('ready', true);
+  },
+  methods: {
+    initMap() {
+      const { map } = getMapInstance(this.mapId, {
+        constrainExtent: this.constrainExtent,
+      });
+      const layers = this.baseLayers.map((l) => createLayerFromConfig(l, this));
+      layers.forEach((l) => {
+        map.addLayer(l);
+      });
+
+      const overlayLayers = this.overlayConfigs.map((l) => createLayerFromConfig(l, this));
+      overlayLayers.forEach((l) => {
+        map.addLayer(l);
+      });
+
+      const view = map.getView();
+      map.on('moveend', () => {
+        this.updateOverlayOpacity(overlayLayers, view);
+      });
+      this.updateOverlayOpacity(overlayLayers, view);
+      this.loaded = true;
+    },
+    updateOverlayOpacity(overlayLayers, view) {
+      const zoom = Math.floor(view.getZoom());
+      overlayLayers.forEach((l) => {
+        if (l.get('name') === 'Country vectors' || (l.get('updateOpacityOnZoom'))) {
+          l.setOpacity(this.opacityCountries[zoom]);
+        }
+      });
+    },
+    overlayCallback(indicatorObject) {
+      this.tooltip = formatLabel(indicatorObject, this);
+    },
+  },
+  beforeDestroy() {
+    // cleanly remove all layers
+    getMapInstance(this.mapId).map.setLayerGroup(new LayerGroup());
+  },
+};
+</script>
+<style lang="scss" scoped>
+
+.tooltip {
+  position: relative;
+  font-size: 14px;
+  box-shadow: none !important;
+  background: rgba(0, 0, 0, 0.6);
+  color: #FFFFFF;
+}
+
+.tooltip:after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border: 10px solid transparent;
+  border-top-color: rgba(0, 0, 0, 0.6);
+  border-bottom: 0;
+  margin-left: -10px;
+  margin-bottom: -10px;
+}
+</style>

--- a/app/src/components/map/layers.js
+++ b/app/src/components/map/layers.js
@@ -17,6 +17,12 @@ const countriesSource = new VectorSource({
 /**
  * generate a layer from a given config Object
  * @param {Object} config eodash config object
+ *
+ * generic GeoJSON Vector Layer.
+ * optional styling via config
+ * @param {string} config.style.fillColor fill color
+ * @param {number} config.style.weight stroke weight
+ * @param {string} config.style.color stroke color
  * @param {*} vm vue instance
  * @returns {*} returns ol layer
  */
@@ -33,6 +39,25 @@ export function createLayerFromConfig(config) {
         stroke: new Stroke({
           width: 1,
           color: '#a2a2a2',
+        }),
+      }),
+    });
+  }
+  if (config.protocol === 'GeoJSON') {
+    return new VectorLayer({
+      name: config.name,
+      visible: config.visible,
+      updateOpacityOnZoom: false,
+      source: new VectorSource({
+        features: geoJsonFormat.readFeatures(config.data),
+      }),
+      style: new Style({
+        fill: new Fill({
+          color: config.style.fillColor || 'rgba(0, 0, 0, 0.5)',
+        }),
+        stroke: new Stroke({
+          width: config.style.weight || 3,
+          color: config.style.color || 'rgba(0, 0, 0, 0.5)',
         }),
       }),
     });

--- a/app/src/components/map/map.js
+++ b/app/src/components/map/map.js
@@ -11,7 +11,7 @@ import './olControls.css';
 
 
 class VueMap {
-  constructor(id) {
+  constructor(id, options) {
     this.controls = [
       new FullScreen({
         className: 'v-card primary--text ol-full-screen',
@@ -43,6 +43,8 @@ class VueMap {
         zoom: 0,
         center: [0, 0],
         padding: [0, 0, 0, 0],
+        extent: options.constrainExtent,
+        constrainOnlyCenter: true,
         enableRotation: false,
       }),
     });
@@ -55,12 +57,14 @@ const mapRegistry = {};
  * Returns the ol map with the given id.
  * Will instantiate a new map if not already existing.
  * @param {string} id id of map
+ * @param {Object} options options
+ * @param {Array} options.constrainExtent optional constraining extent
  * @returns {Map} ol map
  */
-export default function getMapInstance(id) {
+export default function getMapInstance(id, options = {}) {
   const map = mapRegistry[id];
   if (!map) {
-    mapRegistry[id] = new VueMap(id);
+    mapRegistry[id] = new VueMap(id, options);
   }
   return mapRegistry[id];
 }

--- a/app/src/config/trilateral.js
+++ b/app/src/config/trilateral.js
@@ -559,10 +559,14 @@ export const baseLayersRightMap = [{
 }, baseLayers.cloudless];
 
 export const overlayLayersLeftMap = [{
-  ...overlayLayers.eoxOverlay, visible: true,
+  ...overlayLayers.eoxOverlay,
+  visible: true,
+  updateOpacityOnZoom: true,
 }];
 export const overlayLayersRightMap = [{
-  ...overlayLayers.eoxOverlay, visible: true,
+  ...overlayLayers.eoxOverlay,
+  visible: true,
+  updateOpacityOnZoom: true,
 }];
 
 const mapBoxHighResoSubst = [{

--- a/app/src/store/modules/features.js
+++ b/app/src/store/modules/features.js
@@ -1,9 +1,9 @@
 /* eslint no-shadow: ["error", { "allow": ["state", "getters"] }] */
-import WKT from 'ol/format/WKT';
+import { Wkt } from 'wicket';
 import { latLng } from 'leaflet';
 import countriesJson from '@/assets/countries.json';
 
-const format = new WKT();
+const format = new Wkt();
 
 let globalIdCounter = 0;
 const state = {
@@ -306,22 +306,24 @@ const actions = {
             Object.entries(pM).forEach(([key, value]) => {
               if (Object.prototype.hasOwnProperty.call(data[rr], value)) {
                 if (key === 'subAoi') {
-                  // dummy empty geometry
-                  let ftrs = [];
                   try {
                     // assuming sub-aoi does not change over time
                     if (!['', '/'].includes(data[rr][value])) {
-                      ftrs = [
-                        Object.freeze(format.readFeature(data[rr][value], {
-                          dataProjection: 'EPSG:4326',
-                          featureProjection: 'EPSG:3857',
-                        })),
-                      ];
+                      format.read(data[rr][value]);
+                      const jsonGeom = format.toJson();
+                      // create a feature collection
+                      featureObjs[uniqueKey][key] = Object.freeze({
+                        type: 'FeatureCollection',
+                        features: [{
+                          type: 'Feature',
+                          properties: {},
+                          geometry: jsonGeom,
+                        }],
+                      });
                     }
                   } catch (err) {
                     console.log(`Error parsing subAoi of locations for index ${rr}`);
                   }
-                  featureObjs[uniqueKey][key] = ftrs;
                 } else if (key === 'lastMeasurement') {
                   featureObjs[uniqueKey][key] = data[rr][value].length !== 0
                     ? Number(data[rr][value]) : NaN;


### PR DESCRIPTION
This PR brings the initial version of the OpenLayers Indicator Map.
The general structure still reminds of the old one, mainly to display the old features in the new environment. However, a move towards a "single-map"-application (with possible additional maps in the form of stories) should not be far off, as the same map class is used and the foundation to work intensively with configs is laid. Special layers, like the cluster layer of the (now) `CenterMap` or the State Border layer could be special configs, or plugged into a consisting map via props.

The `fit` of the view when clicking on an indicator with a subAoi is now handled with a padding in css pixels, in contrast to the existing calculation with a padding in geographic coordinates. 

A similar calculation for the constraining extent has been replaced by OpenLayers `extent` option, to (softly) force the center of the view to be inside the extent of the given subAoi.

