### PR TITLE
Stories mobile layout

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -114,10 +114,6 @@ export default {
     }
   },
   mounted() {
-    this.fixFullHeight();
-    window.addEventListener('resize', () => {
-      this.fixFullHeight();
-    });
     // Listen for features added, and select if poi in query
     this.$store.subscribe((mutation) => {
       if (mutation.type === 'features/ADD_NEW_FEATURES') {
@@ -213,12 +209,6 @@ export default {
     this.setAreaFromQuery();
   },
   methods: {
-    fixFullHeight() {
-      // First we get the viewport height and we multiple it by 1% to get a value for a vh unit
-      const vh = window.innerHeight * 0.01;
-      // Then we set the value in the --vh custom property to the root of the document
-      document.documentElement.style.setProperty('--vh', `${vh}px`);
-    },
     async checkComingSoon() {
       const currentTime = await this.getCurrentTime();
       this.countDownTime = new Date(this.appConfig.countDownTimer) - currentTime;

--- a/app/src/components/CustomDashboardGrid.vue
+++ b/app/src/components/CustomDashboardGrid.vue
@@ -10,7 +10,7 @@
         Error: {{ element }}
       </v-col>
       <v-col
-        v-else-if="!($vuetify.breakpoint.xsOnly && !!element.text)"
+        v-else
         :key="element.poi"
         cols="12"
         :md="element.width > 1 ? (element.width > 2 ? (element.width > 3 ? 12 : 8) : 6) : 4"
@@ -51,20 +51,7 @@
             tile
           >
             <div
-              v-if="features[index + 1] && features[index + 1].text
-                && $vuetify.breakpoint.xsOnly && !showText"
               class="fill-height"
-              :style="`position: absolute; width: 100%;
-                box-shadow: ${$vuetify.theme.dark ? '#363636' : 'white'} 0px -80px 30px -35px inset;
-                z-index: 3; pointer-events: none;`"
-            >
-            </div>
-            <div
-              :style="`position: relative; height: ${($vuetify.breakpoint.xsOnly
-              && features[index + 1]
-              && features[index + 1].text)
-                ? '60%'
-                : '100%'}`"
             >
               <div
                 v-if="element.text"
@@ -127,47 +114,6 @@
                 style="top: 0px; position: absolute;"
               />
             </div>
-            <template
-              v-if="$vuetify.breakpoint.xsOnly && features[index + 1] && features[index + 1].text"
-            >
-              <div
-                class="mobilePaddingBottom"
-                style="height: calc(var(--vh, 1vh) * 40)"
-              >
-              </div>
-              <v-navigation-drawer
-                v-model="showText"
-                absolute
-                bottom
-                temporary
-                style="z-index: 1; max-height: 100%;"
-                v-touch="{
-                  up: () => startFullScreenInteraction(`#textAreaContainer-${index}`),
-                  down: () => endFullScreenInteraction(`#textAreaContainer-${index}`),
-                }"
-              >
-                <div
-                  :id="`textAreaContainer-${index}`"
-                  class="textAreaContainer fill-height"
-                  :style="!showText ? 'overflow-y: hidden' : ''"
-                >
-                  <v-btn
-                    icon
-                    :dark="$vuetify.theme.dark ? true : false"
-                    absolute
-                    class="ma-2"
-                    style="right: 0"
-                    @click="showText = !showText"
-                  >
-                    <v-icon>{{  showText ? 'mdi-chevron-down' : 'mdi-chevron-up' }}</v-icon>
-                  </v-btn>
-                  <div
-                    class="pa-5 textArea"
-                    v-html="convertToMarkdown(features[index + 1].text)"
-                  ></div>
-                </div>
-              </v-navigation-drawer>
-            </template>
           </v-card>
           <template v-if="enableEditing">
             <div class="buttonContainer containerRight containerTop">
@@ -448,7 +394,6 @@ export default {
     enableCompare: {},
     savedPoi: null,
     offsetTop: 0,
-    showText: false,
     tooltipTrigger: false,
   }),
   computed: {
@@ -700,16 +645,6 @@ export default {
           indicatorObject,
         };
       }));
-    },
-    startFullScreenInteraction(selector) {
-      if (document.querySelector(selector).scrollTop === 0) {
-        this.showText = true;
-      }
-    },
-    endFullScreenInteraction(selector) {
-      if (document.querySelector(selector).scrollTop === 0) {
-        this.showText = false;
-      }
     },
   },
 };

--- a/app/src/components/CustomDashboardGrid.vue
+++ b/app/src/components/CustomDashboardGrid.vue
@@ -461,7 +461,9 @@ export default {
       let noOfRows;
       if (this.navigationButtonVisible) {
         const container = document.querySelector('#elementsContainer').clientHeight;
-        const row = window.innerHeight - this.$vuetify.application.top - this.$vuetify.application.footer;
+        const row = window.innerHeight
+          - this.$vuetify.application.top
+          - this.$vuetify.application.footer;
         noOfRows = Math.round(container / row);
       }
       return noOfRows;
@@ -470,7 +472,9 @@ export default {
       let currentRow;
       if (this.numberOfRows) {
         currentRow = Math.round((this.offsetTop - document.querySelector('#headerRow').clientHeight)
-          / (window.innerHeight - this.$vuetify.application.top - this.$vuetify.application.footer)) + 1;
+          / (window.innerHeight
+            - this.$vuetify.application.top
+            - this.$vuetify.application.footer)) + 1;
       }
       return currentRow;
     },
@@ -584,7 +588,9 @@ export default {
         position = 0; // scroll back to story intro
       } else {
         const startingPoint = document.querySelector('#elementsContainer').offsetTop;
-        const rowHeight = window.innerHeight - this.$vuetify.application.top - this.$vuetify.application.footer;
+        const rowHeight = window.innerHeight
+          - this.$vuetify.application.top
+          - this.$vuetify.application.footer;
         const target = rowHeight * (this.currentRow - 1 + direction);
         position = startingPoint + target;
       }

--- a/app/src/components/CustomDashboardGrid.vue
+++ b/app/src/components/CustomDashboardGrid.vue
@@ -4,6 +4,7 @@
     v-else
     id="elementsContainer"
     v-scroll:#scroll-target="onScroll"
+    :class="storyMode ? 'ma-0' : ''"
   >
     <template v-for="(element, index) in features">
       <v-col v-if="!element.indicatorObject && !element.text" :key="index" cols="12">
@@ -15,11 +16,15 @@
         cols="12"
         :md="element.width > 1 ? (element.width > 2 ? (element.width > 3 ? 12 : 8) : 6) : 4"
         style="position: relative;"
-        :class="$vuetify.breakpoint.xsOnly ? 'px-0' : ''"
+        :class="storyMode ? 'px-0 py-0' : ''"
       >
         <div
           class="d-flex flex-column"
-          :style="`height: ${storyMode ? 'calc((var(--vh, 1vh) * 100) - 140px)' : '500px'}`"
+          :style="`height: ${storyMode
+            ? `calc(var(--vh, 1vh) * ${$vuetify.breakpoint.xsOnly
+              ? getElementHeight(element.width)
+              : 100})`
+            : '500px'}`"
         >
           <div
             v-if="!storyMode"
@@ -47,7 +52,7 @@
           </div>
           <v-card
             class="pa-0 flex-grow-1 elementCard"
-            outlined
+            :outlined="!storyMode"
             tile
           >
             <div
@@ -456,7 +461,7 @@ export default {
       let noOfRows;
       if (this.navigationButtonVisible) {
         const container = document.querySelector('#elementsContainer').clientHeight;
-        const row = document.querySelector('.elementCard').clientHeight;
+        const row = window.innerHeight - this.$vuetify.application.top - this.$vuetify.application.footer;
         noOfRows = Math.round(container / row);
       }
       return noOfRows;
@@ -465,7 +470,7 @@ export default {
       let currentRow;
       if (this.numberOfRows) {
         currentRow = Math.round((this.offsetTop - document.querySelector('#headerRow').clientHeight)
-          / document.querySelector('.elementCard').clientHeight) + 1;
+          / (window.innerHeight - this.$vuetify.application.top - this.$vuetify.application.footer)) + 1;
       }
       return currentRow;
     },
@@ -579,7 +584,7 @@ export default {
         position = 0; // scroll back to story intro
       } else {
         const startingPoint = document.querySelector('#elementsContainer').offsetTop;
-        const rowHeight = document.querySelector('.elementCard').parentElement.parentElement.clientHeight;
+        const rowHeight = window.innerHeight - this.$vuetify.application.top - this.$vuetify.application.footer;
         const target = rowHeight * (this.currentRow - 1 + direction);
         position = startingPoint + target;
       }
@@ -645,6 +650,31 @@ export default {
           indicatorObject,
         };
       }));
+    },
+    getElementHeight(size) {
+      let percent;
+      switch (size) {
+        case 1: {
+          percent = 33.5;
+          break;
+        }
+        case 2: {
+          percent = 50;
+          break;
+        }
+        case 3: {
+          percent = 66.5;
+          break;
+        }
+        case 4: {
+          percent = 100;
+          break;
+        }
+        default: {
+          percent = 100;
+        }
+      }
+      return percent;
     },
   },
 };

--- a/app/src/components/GlobalFooter.vue
+++ b/app/src/components/GlobalFooter.vue
@@ -72,10 +72,12 @@ export default {
   methods: {
     fixFullHeight() {
       // First we get the viewport height and we multiple it by 1% to get a value for a vh unit
-      const vh = (window.innerHeight - this.$vuetify.application.top - this.$vuetify.application.footer) * 0.01;
+      const vh = (window.innerHeight
+        - this.$vuetify.application.top
+        - this.$vuetify.application.footer) * 0.01;
       // Then we set the value in the --vh custom property to the root of the document
       document.documentElement.style.setProperty('--vh', `${vh}px`);
     },
-  }
+  },
 };
 </script>

--- a/app/src/components/GlobalFooter.vue
+++ b/app/src/components/GlobalFooter.vue
@@ -63,5 +63,19 @@ export default {
   components: {
     FeedbackButton,
   },
+  mounted() {
+    this.fixFullHeight();
+    window.addEventListener('resize', () => {
+      this.fixFullHeight();
+    });
+  },
+  methods: {
+    fixFullHeight() {
+      // First we get the viewport height and we multiple it by 1% to get a value for a vh unit
+      const vh = (window.innerHeight - this.$vuetify.application.top - this.$vuetify.application.footer) * 0.01;
+      // Then we set the value in the --vh custom property to the root of the document
+      document.documentElement.style.setProperty('--vh', `${vh}px`);
+    },
+  }
 };
 </script>

--- a/app/src/views/DashboardCustom.vue
+++ b/app/src/views/DashboardCustom.vue
@@ -4,9 +4,9 @@
     class="fill-height scrollContainer"
     :class="$vuetify.breakpoint.smAndAbove
       ? 'pa-10 pt-5'
-      : 'pa-5'"
+      : (storyModeEnabled ? 'pa-0' : 'pa-5')"
       :style="`margin-top: ${$vuetify.application.top}px;
-        height: calc(100% - ${$vuetify.application.top + $vuetify.application.footer}px);
+        height: calc((var(--vh, 1vh) * 100);
         overflow-y: ${storyModeEnabled ? 'hidden' : 'auto'}; overflow-x: hidden`"
     id="scroll-target"
   >
@@ -32,11 +32,11 @@
     </template>
     <template v-else>
       <v-row
-        class="d-flex my-0 mt-n5"
+        class="d-flex my-0"
         id="headerRow"
+        :class="storyModeEnabled ? 'pa-5' : ''"
         :style="`position: relative; ${storyModeEnabled
-          ? `height: calc((var(--vh, 1vh) * 100) - ${$vuetify.application.top
-            + $vuetify.application.footer}px)`
+          ? `height: calc(var(--vh, 1vh) * 100)`
             : ''}`"
       >
         <v-img
@@ -438,7 +438,10 @@
           </div>
         </v-col>
       </v-row>
-      <v-divider v-if="$vuetify.breakpoint.smAndDown" class="my-10"></v-divider>
+      <v-divider
+        v-if="$vuetify.breakpoint.smAndDown && !storyModeEnabled"
+        class="my-10"
+      ></v-divider>
       <custom-dashboard-grid
         ref="customDashboardGrid"
         v-if="$store.state.features.allFeatures.length > 0"
@@ -980,7 +983,7 @@ export default {
     scrollToStart() {
       this.pageScroll({
         target: this.$refs.customDashboardGrid,
-        offset: -56,
+        offset: -1 * this.$vuetify.application.top,
       });
     },
     pageScroll({ target, offset = 0 }) {


### PR DESCRIPTION
This PR introduces a more versatile story layout for mobile screens:
- horizontal story layouts (columns) from desktop are translated into vertical ones on mobile
- all text fields can be expanded by swiping
- number of pages on mobile is equal to page number on desktop

Some images:

![image](https://user-images.githubusercontent.com/26576876/163687875-29ab78f1-fb1f-4b41-9e39-03f87a8d5bab.png)
![image](https://user-images.githubusercontent.com/26576876/163688229-e29cfc69-b724-41a8-83fb-c9974f612a2d.png)

![image](https://user-images.githubusercontent.com/26576876/163688316-70bb840a-3359-4e9e-a5b5-7b2d0cf08e62.png)
![image](https://user-images.githubusercontent.com/26576876/163688248-cf0f4f25-edc7-43fe-ab94-0eae21ad1f58.png)


![image](https://user-images.githubusercontent.com/26576876/163688325-24bc1efe-f228-4396-820e-2ed46af303cb.png)
![image](https://user-images.githubusercontent.com/26576876/163688257-03dfdfa5-f272-413c-ac29-3ed75e7efeac.png)

![image](https://user-images.githubusercontent.com/26576876/163688336-662763fd-3d4e-40a5-ae44-536b2940b449.png)
![image](https://user-images.githubusercontent.com/26576876/163688263-954ac3f2-323f-40ad-9940-18df17bebf18.png)

![image](https://user-images.githubusercontent.com/26576876/163688342-64d2fe08-61da-41d6-942e-6c56a7e1bffd.png)
![image](https://user-images.githubusercontent.com/26576876/163688268-386bd390-51b6-46d0-ab5c-8fe0c8a49465.png)
![story](https://user-images.githubusercontent.com/26576876/163688281-c48d7ef3-d954-4829-83f2-d74dc773040b.gif)









