### PR TITLE
fix: wait for component mount before retrieving headerRow height

### DIFF
--- a/app/src/components/CustomDashboardGrid.vue
+++ b/app/src/components/CustomDashboardGrid.vue
@@ -431,6 +431,7 @@ export default {
     LoadingAnimation,
   },
   data: () => ({
+    isMounted: false,
     features: [],
     dialog: false,
     featureTitle: '',
@@ -513,7 +514,11 @@ export default {
       };
     },
     navigationButtonVisible() {
-      return this.offsetTop >= document.querySelector('#headerRow').clientHeight;
+      let visible;
+      if (this.isMounted) {
+        visible = this.offsetTop >= document.querySelector('#headerRow').clientHeight;
+      }
+      return visible;
     },
     currentRow() {
       let currentRow;
@@ -555,6 +560,9 @@ export default {
         this.getNumberOfRows();
       }
     },
+  },
+  mounted() {
+    this.isMounted = true;
   },
   methods: {
     ...mapActions('dashboard', [


### PR DESCRIPTION
This PR fixes an issue where in some occasions the `#headerRow` would load only after the `navigationButtonVisible` computed property tried accessing it, resulting in a broken navigation button with missing current/total page display.