### PR TITLE
fix: use image description as img title

### DIFF
--- a/app/src/components/CustomDashboardGrid.vue
+++ b/app/src/components/CustomDashboardGrid.vue
@@ -627,7 +627,11 @@ export default {
     convertToMarkdown(text) {
       // each time markdown is rendered, register its images for the zoom feature
       this.registerImageZoom();
-      return this.$marked(text.replace(this.imageFlag, '<img class="featuredImage" src="').replace(this.imageFlag, '" title="test"/>'));
+      return this.$marked(text
+        .replace(this.imageFlag, '<img class="featuredImage" src="')
+        .replace(this.imageFlag, `" title="${text.includes(this.imageFlag)
+          ? text.split(this.imageFlag)[2]
+          : 'Image'}"/>`));
     },
     registerImageZoom() {
       this.$nextTick(() => {


### PR DESCRIPTION
This PR dynamically creates image titles based on the entered description