### PR TITLE
fix: add offset calculation buffer

### DIFF
--- a/app/src/components/CustomDashboardGrid.vue
+++ b/app/src/components/CustomDashboardGrid.vue
@@ -516,7 +516,10 @@ export default {
     navigationButtonVisible() {
       let visible;
       if (this.isMounted) {
-        visible = this.offsetTop >= document.querySelector('#headerRow').clientHeight;
+        // adding 5 pixels here just to make sure it triggers
+        // apparently there are very slight differences between browsers
+        // in offsetTop calculation when the window is zoomed in or out
+        visible = this.offsetTop + 5 >= document.querySelector('#headerRow').clientHeight;
       }
       return visible;
     },


### PR DESCRIPTION
This PR fixes an issue where on Chrome browsers, when zoomed in, the offsetTop would be calculated in a slightly different manner, resulting the navigation arrows not showing in the story mode. This is more of a workaround than a fix, but didn't find any cleaner solution after some research...

Also see this [comment referencing offset in browsers](https://api.jquery.com/offset/):
> Also, dimensions may be incorrect when the page is zoomed by the user; browsers do not expose an API to detect this condition.