### PR TITLE
Fix height calculation and navigation reset after window resize

### DIFF
--- a/app/src/components/CustomDashboardGrid.vue
+++ b/app/src/components/CustomDashboardGrid.vue
@@ -567,6 +567,12 @@ export default {
   },
   mounted() {
     this.isMounted = true;
+
+    window.addEventListener('resize', () => {
+      setTimeout(() => {
+        this.goStep(0);
+      }, 200);
+    });
   },
   methods: {
     ...mapActions('dashboard', [

--- a/app/src/components/CustomDashboardGrid.vue
+++ b/app/src/components/CustomDashboardGrid.vue
@@ -460,6 +460,7 @@ export default {
     showTextCurrent: null,
     tooltipTrigger: false,
     numberOfRows: null,
+    ro: null,
   }),
   computed: {
     ...mapGetters('dashboard', {
@@ -568,11 +569,15 @@ export default {
   mounted() {
     this.isMounted = true;
 
-    window.addEventListener('resize', () => {
+    this.ro = new ResizeObserver(() => {
       setTimeout(() => {
         this.goStep(0);
       }, 200);
-    });
+    })
+      .observe(document.querySelector('.scrollContainer'));
+  },
+  beforeDestroy() {
+    delete this.ro;
   },
   methods: {
     ...mapActions('dashboard', [
@@ -666,6 +671,10 @@ export default {
       if (this.currentRow === 1 && direction === -1) {
         position = 0; // scroll back to story intro
       } else {
+        const container = document.querySelector('#elementsContainer');
+        if (!container) {
+          return;
+        }
         const startingPoint = document.querySelector('#elementsContainer').offsetTop;
         const rowHeight = window.innerHeight
           - this.$vuetify.application.top

--- a/app/src/components/GlobalFooter.vue
+++ b/app/src/components/GlobalFooter.vue
@@ -66,7 +66,9 @@ export default {
   mounted() {
     this.fixFullHeight();
     window.addEventListener('resize', () => {
-      this.fixFullHeight();
+      setTimeout(() => {
+        this.fixFullHeight();
+      }, 200);
     });
   },
   methods: {


### PR DESCRIPTION
This PR tries to fix the window resizing bug in stories by introducing a waiting period to a)recalculate vh and b) reset the position. When going from mobile to desktop now it seems to always reset to the first page, but that's not a big issue, th important thing is it is not broken anymore.