### PR TITLE
Fix selected indicator bleeding

### DIFF
--- a/app/src/components/GlobalHeader.vue
+++ b/app/src/components/GlobalHeader.vue
@@ -99,9 +99,7 @@
           text
           color="primary"
           block
-          @click="$store.state.indicators.selectedIndicator
-            ? $router.go(-1)
-            : $router.push({ name: 'explore' })"
+          :to="{ name: 'explore' }"
         >
           Explore Datasets
       </v-btn>
@@ -262,9 +260,7 @@
         text
         dark
         small
-        @click="$store.state.indicators.selectedIndicator
-          ? $router.go(-1)
-          : $router.push({ name: 'explore' })"
+        :to="{ name: 'explore' }"
       >
         Explore Datasets
       </v-btn>

--- a/app/src/views/Dashboard.vue
+++ b/app/src/views/Dashboard.vue
@@ -321,6 +321,9 @@ export default {
       }
     }, 2000);
   },
+  beforeDestroy() {
+    this.$store.commit('indicators/SET_SELECTED_INDICATOR', null);
+  },
   methods: {
     setDataPanelWidth(enable) {
       if (enable) {


### PR DESCRIPTION
This PR fixes the issue of the broken "explore" navigation button in the header caused by a `selectedIndicator` stored in the store. Also now, each time the user navigates away from the explore page, the selected indicator is reset. This causes just a slight inconvenience when navigating back from a custom dashboard (takes a bit longer to load), but brings the benefit of the `selectedIndicator` not bleeding into the rest of the application and causing trouble.