### PR TITLE
Timelapse endpoint extend

### DIFF
--- a/app/src/components/IndicatorData.vue
+++ b/app/src/components/IndicatorData.vue
@@ -96,7 +96,7 @@ export default {
     return {
       dataLayerTime: null,
       lineChartIndicators: [
-        'E12', 'E12b', 'E8', 'N1b', 'N1', 'N3', 'N3b',
+        'E12', 'E12b', 'E8', 'N1b', 'N1', 'NASACustomLineChart', 'N3', 'N3b',
         'GG', 'E10a', 'E10a9', 'CV', 'OW', 'E10c', 'E10a10', 'OX',
         'N1a', 'N1b', 'N1c', 'N1d', 'E12b', 'E8', 'N9',
         'E13o', 'E13p', 'E13q', 'E13r', 'CDS1', 'CDS2', 'CDS3', 'CDS4',
@@ -287,6 +287,22 @@ export default {
             ],
             valueDecompose: (item) => (item.replace(/[[\] ]/g, '').split(',')
               .map((str) => (str === '' ? Number.NaN : Number(str)))),
+          },
+          NASACustomLineChart: {
+            measurementConfig: {
+              label: indicator.yAxis,
+              fill: false,
+              backgroundColor: refColors[0],
+              borderColor: refColors[0],
+              spanGaps: false,
+              borderWidth: 2,
+            },
+            referenceData: [
+              {
+                key: 'Median', index: 0, color: 'black', fill: false,
+              },
+            ],
+            valueDecompose: (item) => Number(item),
           },
         };
         referenceDecompose.N1b = referenceDecompose.N1a;
@@ -845,7 +861,7 @@ export default {
         || this.$store.state.indicators.selectedIndicator;
     },
     indDefinition() {
-      return this.baseConfig.indicatorsDefinition[this.indicatorObject.indicator];
+      return this.baseConfig.indicatorsDefinition[this.indicatorObject.indicator] || {};
     },
   },
   methods: {

--- a/app/src/components/IndicatorMap.vue
+++ b/app/src/components/IndicatorMap.vue
@@ -415,7 +415,6 @@ import turfDifference from '@turf/difference';
 import countries from '@/assets/countries.json';
 import gsaFile from '@/assets/gsa_data.json';
 
-
 import {
   createConfigFromIndicator,
   createAvailableTimeEntries,
@@ -1380,6 +1379,7 @@ export default {
     fetchCustomAreaIndicator() {
       this.fetchData({
         type: 'customIndicator',
+        side: 'data',
       });
     },
     clearCustomAreaFilter() {

--- a/app/src/config/trilateral.js
+++ b/app/src/config/trilateral.js
@@ -1137,7 +1137,7 @@ export const globalIndicators = [
           minMapZoom: 1,
           maxZoom: 10,
           maxMapZoom: 10,
-          url: 'https://ejd872yh78.execute-api.us-east-1.amazonaws.com/cog/tiles/WebMercatorQuad/{z}/{x}/{y}?{time}&resampling_method=bilinear&rescale=-126905900761088.0,3673290589614899.0&bidx=1&colormap_name=reds',
+          url: 'https://ejd872yh78.execute-api.us-east-1.amazonaws.com/cog/tiles/WebMercatorQuad/{z}/{x}/{y}?{time}&resampling_method=bilinear&rescale=0,108e14&bidx=1&colormap_name=reds',
           name: 'NO2 OMI Annual',
           dateFormatFunction: (date) => `url=${date[1]}`,
           labelFormatFunction: (date) => DateTime.fromISO(date[0]).toFormat('yyyy'),

--- a/app/src/config/trilateral.js
+++ b/app/src/config/trilateral.js
@@ -908,7 +908,7 @@ export const globalIndicators = [
           customAreaIndicator: true,
           areaIndicator: nasaTimelapseConfig(
             'no2-diff',
-            ['201501', DateTime.now().toFormat('yyyyMM')],
+            ['201501', DateTime.utc().toFormat('yyyyMM')],
             (value) => value / 1e15,
           ),
         },
@@ -1130,7 +1130,7 @@ export const globalIndicators = [
         inputData: [''],
         display: {
           // mosaicIndicator: true,
-          collection: 'OMI_trno2-COG',
+          // collection: 'OMI_trno2-COG',
           protocol: 'xyz',
           tileSize: 256,
           minZoom: 1,
@@ -1169,7 +1169,7 @@ export const globalIndicators = [
         showGlobe: true,
         display: {
           // mosaicIndicator: true,
-          collection: 'IS2SITMOGR4',
+          // collection: 'IS2SITMOGR4',
           protocol: 'xyz',
           tileSize: 256,
           minZoom: 1,
@@ -1207,7 +1207,7 @@ export const globalIndicators = [
         inputData: [''],
         display: {
           // mosaicIndicator: true,
-          collection: 'MO_NPP_npp_vgpm',
+          // collection: 'MO_NPP_npp_vgpm',
           protocol: 'xyz',
           tileSize: 256,
           minZoom: 1,
@@ -1245,7 +1245,7 @@ export const globalIndicators = [
         inputData: [''],
         display: {
           // mosaicIndicator: true,
-          collection: 'nceo_africa_2017',
+          // collection: 'nceo_africa_2017',
           protocol: 'xyz',
           tileSize: 256,
           minZoom: 1,
@@ -1291,7 +1291,7 @@ export const globalIndicators = [
         inputData: [''],
         display: {
           // mosaicIndicator: true,
-          collection: 'OMSO2PCA-COG',
+          // collection: 'OMSO2PCA-COG',
           protocol: 'xyz',
           tileSize: 256,
           minZoom: 1,

--- a/app/src/config/trilateral.js
+++ b/app/src/config/trilateral.js
@@ -14,7 +14,6 @@ import {
   parseStatAPIResponse,
   nasaTimelapseConfig,
 } from '@/helpers/customAreaObjects';
-import store from '../store';
 
 export const dataPath = './data/internal/';
 export const dataEndpoints = [
@@ -893,7 +892,7 @@ export const globalIndicators = [
         aoiID: 'W3',
         time: availableDates['no2-monthly-diff'],
         inputData: [''],
-        yAxis: 'NO2-difference [µmol/m²]',
+        yAxis: 'NO2-difference [10^15 molecules/cm²]',
         display: {
           protocol: 'xyz',
           maxNativeZoom: 6,
@@ -907,7 +906,11 @@ export const globalIndicators = [
           legendUrl: 'data/trilateral/N1-NO2DiffLegend.png',
           disableCompare: true,
           customAreaIndicator: true,
-          areaIndicator: nasaTimelapseConfig('no2-diff'),
+          areaIndicator: nasaTimelapseConfig(
+            'no2-diff',
+            ['201501', DateTime.now().toFormat('yyyyMM')],
+            (value) => value / 1e15,
+          ),
         },
       },
     },
@@ -937,6 +940,7 @@ export const globalIndicators = [
         aoiID: 'W4',
         time: getDailyDates('2020-01-01', '2021-10-15'),
         inputData: [''],
+        yAxis: 'CO2 mean [ppm]',
         display: {
           protocol: 'xyz',
           tileSize: 256,
@@ -946,6 +950,13 @@ export const globalIndicators = [
           dateFormatFunction: (date) => DateTime.fromISO(date).toFormat('yyyy_MM_dd'),
           legendUrl: 'data/trilateral/N2-co2mean-legend.png',
           mapLabel: 'Mean',
+          customAreaIndicator: true,
+          areaIndicator: nasaTimelapseConfig(
+            'co2',
+            ['2020_01_01', '2021_10_15'],
+            (value) => (value * 1e6),
+            'yyyy_MM_dd',
+          ),
         },
         compareDisplay: {
           protocol: 'xyz',
@@ -1030,6 +1041,7 @@ export const globalIndicators = [
         aoiID: 'W5',
         time: getDailyDates('2020-01-01', '2021-10-15'),
         inputData: [''],
+        yAxis: 'CO2 difference [ppm]',
         display: {
           protocol: 'xyz',
           tileSize: 256,
@@ -1039,6 +1051,13 @@ export const globalIndicators = [
           dateFormatFunction: (date) => DateTime.fromISO(date).toFormat('yyyy_MM_dd'),
           legendUrl: 'data/trilateral/N2-co2diff-legend.png',
           disableCompare: true,
+          customAreaIndicator: true,
+          areaIndicator: nasaTimelapseConfig(
+            'co2-diff',
+            ['2020_01_01', '2021_10_15'],
+            (value) => (value * 1e6),
+            'yyyy_MM_dd',
+          ),
         },
       },
     },
@@ -1122,7 +1141,7 @@ export const globalIndicators = [
           name: 'NO2 OMI Annual',
           dateFormatFunction: (date) => `url=${date[1]}`,
           labelFormatFunction: (date) => DateTime.fromISO(date[0]).toFormat('yyyy'),
-          // legendUrl: 'data/trilateral/N2-co2diff-legend.png',
+          legendUrl: 'eodash-data/data/no2Legend.png',
         },
       },
     },
@@ -3559,7 +3578,6 @@ export const globalIndicators = [
   },
 ];
 
-
 const createSlowDownIndicator = (id, aoiID, city, country, aoi, geometry, cog, eoSensor, time) => (
   {
     latlng: aoi,
@@ -3756,7 +3774,6 @@ const slowdownIndicators = [
     cog: 'RiodeJaneiro_S1_TD155_SPM_20200112-20200217_20200324-20200429_th-0.3.cog',
   },
 ];
-
 
 let idOffset = 30000;
 slowdownIndicators.forEach((ind, idx) => (

--- a/app/src/helpers/customAreaObjects.js
+++ b/app/src/helpers/customAreaObjects.js
@@ -387,4 +387,65 @@ const fetchCustomAreaObjects = async (
   return customObjects;
 };
 
+export const nasaTimelapseConfig = (
+    datasetId,
+    dateRange=['201501', DateTime.now().toFormat('yyyyMM')],
+    rescale=((value) => (value / 1e14)),
+  ) => ({
+  url: 'https://8ib71h0627.execute-api.us-east-1.amazonaws.com/v1/timelapse',
+  requestMethod: 'POST',
+  requestHeaders: {
+    'Content-Type': 'application/json',
+  },
+  requestBody: {
+    datasetId,
+    dateRange,
+    geojson: '{geojson}',
+  },
+  callbackFunction: (responseJson, indicator) => {
+    let ind = null;
+    if (Array.isArray(responseJson)) {
+      const data = responseJson;
+      const newData = {
+        time: [],
+        measurement: [],
+        colorCode: [],
+        referenceValue: [],
+      };
+      data.forEach((row) => {
+        if (!('error' in row)) {
+          newData.time.push(DateTime.fromFormat(row.date, 'yyyyMM'));
+          newData.colorCode.push('');
+          newData.measurement.push(rescale(row.mean));
+          newData.referenceValue.push(`[${rescale(row.median)}, null, null, null]`);
+        }
+      });
+      ind = {
+        ...indicator,
+        ...newData,
+      };
+    } else if (Object.keys(responseJson).indexOf('detail') !== -1) {
+      // This will happen if area selection is too large
+      if (responseJson.detail[0].msg.startsWith('AOI cannot exceed')) {
+        store.commit('sendAlert', {
+          message: 'AOI cannot exceed 200 000 km²',
+          type: 'error',
+        });
+      } else {
+        console.log(responseJson.detail[0].msg);
+      }
+    }
+    return ind;
+  },
+  areaFormatFunction: (area) => (
+    {
+      geojson: JSON.stringify({
+        type: 'Feature',
+        properties: {},
+        geometry: area,
+      }),
+    }
+  ),
+});
+
 export default fetchCustomAreaObjects;

--- a/app/src/helpers/customAreaObjects.js
+++ b/app/src/helpers/customAreaObjects.js
@@ -388,10 +388,12 @@ const fetchCustomAreaObjects = async (
 };
 
 export const nasaTimelapseConfig = (
-    datasetId,
-    dateRange=['201501', DateTime.now().toFormat('yyyyMM')],
-    rescale=((value) => (value / 1e14)),
-  ) => ({
+  datasetId,
+  dateRange = ['201501', DateTime.now().toFormat('yyyyMM')],
+  rescale = (value) => value / 1e14,
+  dataTimeFormat = 'yyyyMM',
+  indicatorCode = 'NASACustomLineChart',
+) => ({
   url: 'https://8ib71h0627.execute-api.us-east-1.amazonaws.com/v1/timelapse',
   requestMethod: 'POST',
   requestHeaders: {
@@ -414,12 +416,16 @@ export const nasaTimelapseConfig = (
       };
       data.forEach((row) => {
         if (!('error' in row)) {
-          newData.time.push(DateTime.fromFormat(row.date, 'yyyyMM'));
+          newData.time.push(DateTime.fromFormat(row.date, dataTimeFormat));
           newData.colorCode.push('');
           newData.measurement.push(rescale(row.mean));
-          newData.referenceValue.push(`[${rescale(row.median)}, null, null, null]`);
+          newData.referenceValue.push(rescale(row.median));
         }
       });
+      if (indicatorCode) {
+        // if we for some reason need to change indicator code of custom chart data
+        newData.indicator = indicatorCode;
+      }
       ind = {
         ...indicator,
         ...newData,

--- a/app/src/helpers/customAreaObjects.js
+++ b/app/src/helpers/customAreaObjects.js
@@ -389,7 +389,7 @@ const fetchCustomAreaObjects = async (
 
 export const nasaTimelapseConfig = (
   datasetId,
-  dateRange = ['201501', DateTime.now().toFormat('yyyyMM')],
+  dateRange = ['201501', DateTime.utc().toFormat('yyyyMM')],
   rescale = (value) => value / 1e14,
   dataTimeFormat = 'yyyyMM',
   indicatorCode = 'NASACustomLineChart',


### PR DESCRIPTION
- generalized call to the `/timelapse` endpoint and extended configs so that customAreaIndicator is used also for CO2 + CO2 diff + NO2 OMI diff
- updated rescale range for OMI NO2 yearly to match the NO2 monthly OMI + added reference to the same legend