### PR TITLE
Customize GTIF navigation menu and add breadcrumbs

### DIFF
--- a/app/src/components/FeedbackButton.vue
+++ b/app/src/components/FeedbackButton.vue
@@ -11,12 +11,12 @@
       <v-btn
         dark
         small
-        color="secondary"
+        :color="appConfig.id === 'gtif' ? '#00619e' : 'secondary'"
         class="ml-1"
         @click="dialog = true"
       >
         <v-icon :left="!$vuetify.breakpoint.xsOnly" small>mdi-account-voice</v-icon>
-        <span v-if="!$vuetify.breakpoint.xsOnly">Feedback</span>
+        <span class="feedback-button-text" v-if="!$vuetify.breakpoint.xsOnly">Feedback</span>
       </v-btn>
     </template>
 
@@ -42,6 +42,10 @@
 </template>
 
 <script>
+import {
+  mapState,
+} from 'vuex';
+
 import dialogMixin from '@/mixins/dialogMixin';
 import Feedback from '@/views/Feedback.vue';
 
@@ -53,5 +57,14 @@ export default {
   data: () => ({
     dialog: false,
   }),
+  computed: {
+    ...mapState('config', ['appConfig']),
+  },
 };
 </script>
+
+<style lang="scss" scoped>
+  .feedback-button-text {
+    font-family: 'NotesESABold';
+  }
+</style>

--- a/app/src/components/GTIF/GTIFBreadcrumbs.vue
+++ b/app/src/components/GTIF/GTIFBreadcrumbs.vue
@@ -1,9 +1,9 @@
 <template>
-  <v-row
-    justify="between"
-    align="center"
-  >
-  </v-row>
+  <div class="gtif-breadcrumbs">
+    <div class="fill-width fill-height d-flex justify-between align-center">
+
+    </div>
+  </div>
 </template>
 
 <script>
@@ -25,5 +25,9 @@ export default {
 <style lang="scss" scoped>
 .gtif-breadcrumbs {
   background: #77F;
+  width: 100%;
+  height: 48px;
+  position: fixed;
+  top: 64px;
 }
 </style>

--- a/app/src/components/GTIF/GTIFBreadcrumbs.vue
+++ b/app/src/components/GTIF/GTIFBreadcrumbs.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="gtif-breadcrumbs">
-    <div class="fill-width fill-height d-flex justify-between align-center">
-
+    <div class="fill-width fill-height d-flex justify-between align-center pl-6">
+      <span class="bold">GTIF</span>
+      <span class="px-2">|</span>
+      <span>Green Transition Information Factory</span>
+      <span class="px-2">&gt;</span>
     </div>
   </div>
 </template>
@@ -13,7 +16,7 @@ import {
 } from 'vuex';
 
 export default {
-  name: 'GtifHeaderNavItem',
+  name: 'GtifBreadcrumbs',
   computed: {
     ...mapState('config', [
       'appConfig',
@@ -24,10 +27,16 @@ export default {
 
 <style lang="scss" scoped>
 .gtif-breadcrumbs {
-  background: #77F;
+  background: #1E4B5F;
   width: 100%;
   height: 48px;
   position: fixed;
   top: 64px;
+  font-size: 18px;
+  color: #CDD7DA;
+
+  .bold {
+    font-family: 'NotesESABold';
+  }
 }
 </style>

--- a/app/src/components/GTIF/GTIFBreadcrumbs.vue
+++ b/app/src/components/GTIF/GTIFBreadcrumbs.vue
@@ -4,8 +4,8 @@
       <span class="bold">GTIF</span>
       <span class="px-2">|</span>
       <span>Green Transition Information Factory</span>
-      <span class="px-2 green-crumb">&gt;</span>
-      <span class="green-crumb">{{ currentBreadcrumb }}</span>
+      <span v-if="areBreadcrumbsEnabled" class="px-2 green-crumb">&gt;</span>
+      <span v-if="areBreadcrumbsEnabled" class="green-crumb">{{ currentBreadcrumb }}</span>
     </div>
   </div>
 </template>
@@ -18,6 +18,12 @@ import {
 
 export default {
   name: 'GtifBreadcrumbs',
+  props: {
+    areBreadcrumbsEnabled: {
+      type: Boolean,
+      default: true,
+    },
+  },
   computed: {
     ...mapState('config', [
       'appConfig',

--- a/app/src/components/GTIF/GTIFBreadcrumbs.vue
+++ b/app/src/components/GTIF/GTIFBreadcrumbs.vue
@@ -1,0 +1,29 @@
+<template>
+  <v-row
+    justify="between"
+    align="center"
+  >
+  </v-row>
+</template>
+
+<script>
+// Utilities
+import {
+  mapState,
+} from 'vuex';
+
+export default {
+  name: 'GtifHeaderNavItem',
+  computed: {
+    ...mapState('config', [
+      'appConfig',
+    ]),
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.gtif-breadcrumbs {
+  background: #77F;
+}
+</style>

--- a/app/src/components/GTIF/GTIFBreadcrumbs.vue
+++ b/app/src/components/GTIF/GTIFBreadcrumbs.vue
@@ -4,7 +4,8 @@
       <span class="bold">GTIF</span>
       <span class="px-2">|</span>
       <span>Green Transition Information Factory</span>
-      <span class="px-2">&gt;</span>
+      <span class="px-2 green-crumb">&gt;</span>
+      <span class="green-crumb">{{ currentBreadcrumb }}</span>
     </div>
   </div>
 </template>
@@ -21,6 +22,28 @@ export default {
     ...mapState('config', [
       'appConfig',
     ]),
+
+    currentBreadcrumb() {
+      switch (this.$route.name) {
+        case 'gtif-energy-transition':
+          return 'Energy Transition'
+
+        case 'gtif-mobility-transition':
+          return 'Mobility Transition'
+
+        case 'gtif-sustainable-transition':
+          return 'Sustainable Transition'
+
+        case 'gtif-carbon-finance':
+          return 'Carbon Finance'
+
+        case 'gtif-eo-adaptation':
+          return 'EO Adaptation'
+
+        default:
+          return '';
+      }
+    },
   },
 };
 </script>
@@ -37,6 +60,10 @@ export default {
 
   .bold {
     font-family: 'NotesESABold';
+  }
+
+  .green-crumb {
+    color: #00ae9d;
   }
 }
 </style>

--- a/app/src/components/GTIF/GTIFHeader.vue
+++ b/app/src/components/GTIF/GTIFHeader.vue
@@ -118,37 +118,47 @@
               </v-row>
 
               <GtifHeaderNavItem
-                title="Explore"
+                title="Explore Tools"
+                to="/explore"
+              />
+
+              <GtifHeaderNavItem
+                title="Domains"
                 to="/explore"
               />
 
               <GtifHeaderNavItem
                 color="hsl(360 80% 60%)"
                 title="Energy Transition"
+                is-sub-item="true"
                 :to="{name: 'gtif-energy-transition'}"
               />
 
               <GtifHeaderNavItem
                 color="hsl(210 80% 60%)"
                 title="Mobility Transition"
+                is-sub-item="true"
                 :to="{name: 'gtif-mobility-transition'}"
               />
 
               <GtifHeaderNavItem
                 color="hsl(90 80% 60%)"
                 title="Sustainable Transition"
+                is-sub-item="true"
                 :to="{name: 'gtif-sustainable-transition'}"
               />
 
               <GtifHeaderNavItem
                 color="hsl(20 80% 60%)"
                 title="Carbon Finance"
+                is-sub-item="true"
                 :to="{name: 'gtif-carbon-finance'}"
               />
 
               <GtifHeaderNavItem
                 color="hsl(320 80% 60%)"
                 title="EO Adaptation"
+                is-sub-item="true"
                 :to="{name: 'gtif-eo-adaptation'}"
               />
 

--- a/app/src/components/GTIF/GTIFHeader.vue
+++ b/app/src/components/GTIF/GTIFHeader.vue
@@ -159,7 +159,7 @@
               <GtifHeaderNavItem
                 color="hsl(320 80% 60%)"
                 title="EO Adaptation"
-                is-sub-item="true"
+                :is-sub-item="true"
                 :to="{name: 'gtif-eo-adaptation'}"
               />
 

--- a/app/src/components/GTIF/GTIFHeader.vue
+++ b/app/src/components/GTIF/GTIFHeader.vue
@@ -124,34 +124,35 @@
 
               <GtifHeaderNavItem
                 title="Domains"
+                :is-hoverable="false"
                 to="/explore"
               />
 
               <GtifHeaderNavItem
                 color="hsl(360 80% 60%)"
                 title="Energy Transition"
-                is-sub-item="true"
+                :is-sub-item="true"
                 :to="{name: 'gtif-energy-transition'}"
               />
 
               <GtifHeaderNavItem
                 color="hsl(210 80% 60%)"
                 title="Mobility Transition"
-                is-sub-item="true"
+                :is-sub-item="true"
                 :to="{name: 'gtif-mobility-transition'}"
               />
 
               <GtifHeaderNavItem
                 color="hsl(90 80% 60%)"
                 title="Sustainable Transition"
-                is-sub-item="true"
+                :is-sub-item="true"
                 :to="{name: 'gtif-sustainable-transition'}"
               />
 
               <GtifHeaderNavItem
                 color="hsl(20 80% 60%)"
                 title="Carbon Finance"
-                is-sub-item="true"
+                :is-sub-item="true"
                 :to="{name: 'gtif-carbon-finance'}"
               />
 

--- a/app/src/components/GTIF/GTIFHeaderNavItem.vue
+++ b/app/src/components/GTIF/GTIFHeaderNavItem.vue
@@ -3,11 +3,11 @@
     @click="$router.push(to)"
     class="navrow py-5 fill-width"
     :class="[isSubItem ? 'px-10' : 'px-7']"
+    :style="styleObject"
     align="center"
     >
     <div class="w-12">
       <div
-        :style="{'background': color}"
         class="w-3 h-3 rounded-full dot mr-4"
       ></div>
     </div>
@@ -49,6 +49,15 @@ export default {
     ...mapState('config', [
       'appConfig',
     ]),
+    styleObject: function() {
+      return {
+        '--color-text': '#9fb0bb',
+        '--color-icon': this.isSubItem ? '#00ae9d' : 'rgba(255, 255, 255, 0.267)',
+        '--color-text-hover': this.isHoverable ? '#00ae9d' : '#9fb0bb',
+        '--color-icon-hover': this.isHoverable ? '#00ae9d' : 'rgba(255, 255, 255, 0.28)',
+        '--color-bg-hover':   this.isHoverable ? 'rgba(255, 255, 255, 0.07)' : '#FFF0',
+      }
+    }
   },
 };
 </script>
@@ -60,10 +69,18 @@ export default {
   transition: background-color 0.1s linear, color 0.1s linear;
 
   &:hover {
-    background: rgba(255, 255, 255, 0.07);
+    background: var(--color-bg-hover) !important;
 
-    .name, .home-icon {
-      color: lighten(#8197A6, 90%);
+    .home-icon {
+      color: var(--color-icon-hover);
+    }
+
+    .dot {
+      background: var(--color-icon-hover);
+    }
+
+    .name {
+      color: var(--color-text-hover);
     }
   }
 
@@ -71,12 +88,14 @@ export default {
     width: 12px;
     height: 12px;
     border-radius: 6px;
+    background: var(--color-icon);
+    transition: background-color 0.1s linear;
   }
 
   .name {
     font-size: 18px;
     transition: color 0.1s linear;
-    color: lighten(#8197A6, 10%);
+    color: var(--color-text);
   }
 }
 </style>

--- a/app/src/components/GTIF/GTIFHeaderNavItem.vue
+++ b/app/src/components/GTIF/GTIFHeaderNavItem.vue
@@ -1,7 +1,9 @@
 <template>
   <v-row
     @click="$router.push(to)"
-    class="navrow py-5 px-7 fill-width" align="center"
+    class="navrow py-5 fill-width"
+    :class="[isSubItem ? 'px-10' : 'px-7']"
+    align="center"
     >
     <div class="w-12">
       <div
@@ -34,6 +36,14 @@ export default {
       type: [String, Object],
       required: true,
     },
+    isSubItem: {
+      type: Boolean,
+      default: false,
+    },
+    isHoverable: {
+      type: Boolean,
+      default: true,
+    }
   },
   computed: {
     ...mapState('config', [

--- a/app/src/views/ScrollyFrame.vue
+++ b/app/src/views/ScrollyFrame.vue
@@ -8,15 +8,16 @@
     >
       <global-header />
 
-      <gtif-breadcrumbs v-if="areBreadcrumbsEnabled" />
+      <gtif-breadcrumbs
+        :are-breadcrumbs-enabled="areBreadcrumbsEnabled"
+      />
 
       <iframe
         id="resizableIframe"
         @load="onLoaded"
         v-resize="onResize"
         width="100%"
-        style="height: calc((var(--vh), 1vh) * 100) !important; position: fixed; left: 0; bottom: 0;"
-        :style="{top: areBreadcrumbsEnabled ? '112px' : '64px'}"
+        style="height: calc((var(--vh), 1vh) * 100) !important; position: fixed; left: 0; bottom: 0; top: 112px;"
         
         src="./scrolly.html"
         frameborder="0"
@@ -111,18 +112,16 @@ export default {
       }
     },
     onResize() {
-      let headerHeight = this.areBreadcrumbsEnabled ? 64 + 48 : 64;
-
       iFrameResize({
         // log: true,
         checkOrigin: false,
         inPageLinks: false,
         sizeHeight: false,
         scrolling: true,
-        minHeight: this.minHeight 
+        minHeight: this.minHeight
           || window.innerHeight
               - 64
-              - (this.areBreadcrumbsEnabled ? 48 : 0),
+              - 48,
       }, '#resizableIframe');
     },
     getDashboardID() {

--- a/app/src/views/ScrollyFrame.vue
+++ b/app/src/views/ScrollyFrame.vue
@@ -8,12 +8,15 @@
     >
       <global-header />
 
+      <gtif-breadcrumbs v-if="areBreadcrumbsEnabled" />
+
       <iframe
         id="resizableIframe"
         @load="onLoaded"
         v-resize="onResize"
         width="100%"
         style="height: calc((var(--vh), 1vh) * 100) !important;"
+        :style="{'margin-top': areBreadcrumbsEnabled ? '48px' : '0px'}"
         src="./scrolly.html"
         frameborder="0"
       ></iframe>
@@ -30,10 +33,12 @@ import {
 import axios from 'axios';
 import iFrameResize from 'iframe-resizer/js/iframeResizer';
 import GlobalHeader from '@/components/GlobalHeader.vue';
+import GtifBreadcrumbs from '@/components/GTIF/GTIFBreadcrumbs.vue';
 
 export default {
   components: {
     GlobalHeader,
+    GtifBreadcrumbs,
   },
   metaInfo() {
     const { appConfig } = this.$store.state.config;
@@ -41,14 +46,22 @@ export default {
       title: appConfig ? appConfig.branding.appName : 'eodash',
     };
   },
+  data() {
+    return {
+      areBreadcrumbsEnabled: false,
+    }
+  },
   computed: {
     ...mapState('config', ['appConfig']),
   },
   mounted() {
+    this.setBreadcrumbsEnabled();
+
     window.onmessage = (e) => {
       // Check if we got a navigation request from the iframe.
       if (e.data.type === 'nav') {
         this.$router.push({ name: e.data.dest });
+        this.setBreadcrumbsEnabled();
       }
     };
   },
@@ -97,13 +110,18 @@ export default {
       }
     },
     onResize() {
+      let headerHeight = this.areBreadcrumbsEnabled ? 64 + 48 : 64;
+
       iFrameResize({
         // log: true,
         checkOrigin: false,
         inPageLinks: false,
         sizeHeight: false,
         scrolling: true,
-        minHeight: this.minHeight || window.innerHeight - 64,
+        minHeight: this.minHeight 
+          || window.innerHeight
+              - 64
+              - (this.areBreadcrumbsEnabled ? 48 : 0),
       }, '#resizableIframe');
     },
     getDashboardID() {
@@ -129,6 +147,19 @@ export default {
         // Fallback value
         default:
           return '50826821d453dfd5';
+      }
+    },
+    setBreadcrumbsEnabled() {
+      switch (this.$route.name) {
+        case 'gtif-energy-transition':
+        case 'gtif-mobility-transition':
+        case 'gtif-sustainable-transition':
+        case 'gtif-carbon-finance':
+        case 'gtif-eo-adaptation':
+          this.areBreadcrumbsEnabled = true;
+
+        default:
+          this.areBreadcrumbsEnabled = false;
       }
     },
   },

--- a/app/src/views/ScrollyFrame.vue
+++ b/app/src/views/ScrollyFrame.vue
@@ -15,8 +15,9 @@
         @load="onLoaded"
         v-resize="onResize"
         width="100%"
-        style="height: calc((var(--vh), 1vh) * 100) !important;"
-        :style="{'margin-top': areBreadcrumbsEnabled ? '48px' : '0px'}"
+        style="height: calc((var(--vh), 1vh) * 100) !important; position: fixed; left: 0; bottom: 0;"
+        :style="{top: areBreadcrumbsEnabled ? '112px' : '64px'}"
+        
         src="./scrolly.html"
         frameborder="0"
       ></iframe>
@@ -157,6 +158,7 @@ export default {
         case 'gtif-carbon-finance':
         case 'gtif-eo-adaptation':
           this.areBreadcrumbsEnabled = true;
+          break
 
         default:
           this.areBreadcrumbsEnabled = false;


### PR DESCRIPTION
This pull request contains changes to the GTIF brand as requested in Mariangela's document from October 5, 2022. The following changes were made:

* Add support for indentation of navigation items in the sidebar
* Add new sub-header component containing the breadcrumbs.
* Update styles for the normal and hovered states of the navigation items
* Update color of the feedback button