### PR TITLE
Fix: preset view & pan restrictions

### DIFF
--- a/app/src/components/map/Map.vue
+++ b/app/src/components/map/Map.vue
@@ -6,7 +6,7 @@
       :mapId="mapId"
       :indicator="indicator"
       v-if="dataLayerName"
-      :key="dataLayerName + '_subAoi'"
+      :key="dataLayerKey + '_subAoi'"
     />
     <!-- a layer displaying a selected global poi
      these layers will have z-Index 3 -->
@@ -357,7 +357,7 @@ export default {
       return dataLayerName || '';
     },
     dataLayerKey() {
-      return this.dataLayerName + +this.indicator.aoiID + this.indicator.indicator;
+      return this.dataLayerName + this.indicator.aoiID + this.indicator.indicator;
     },
     countriesJson() {
       return countries;

--- a/app/src/components/map/Map.vue
+++ b/app/src/components/map/Map.vue
@@ -467,7 +467,7 @@ export default {
     },
     zoomExtent: {
       deep: true,
-      immediate: true,
+      immediate: false,
       handler(value) {
         // when the calculated zoom extent changes, zoom the map to the new extent.
         // this is purely cosmetic and does not limit the ability to pan or zoom
@@ -476,7 +476,9 @@ export default {
           const { map } = getMapInstance(this.mapId);
           if (map.getTargetElement()) {
             const padding = calculatePadding();
-            map.getView().fit(value, { duration: 500, padding });
+            setTimeout(() => {
+              map.getView().fit(value, { duration: 500, padding });
+            }, 30);
           } else {
             map.once('change:target', () => {
               map.getView().fit(value);

--- a/app/src/components/map/Map.vue
+++ b/app/src/components/map/Map.vue
@@ -369,6 +369,12 @@ export default {
           || (!this.indicator?.subAoi?.features && !this.mergedConfigsData[0]?.presetView)) {
         return null;
       }
+      const presetView = this.mergedConfigsData[0]?.presetView;
+      if (presetView) {
+        // pre-defined geojson view
+        const presetViewGeom = geoJsonFormat.readGeometry(presetView.features[0].geometry);
+        return presetViewGeom.getExtent();
+      }
       const { subAoi } = this.indicator;
       if (subAoi && subAoi.features.length) {
         if (subAoi.features[0].geometry.coordinates.length) {
@@ -377,12 +383,6 @@ export default {
         }
         // geoJsonFormat
         return []; // this.subAoi[0].getGeometry().getExtent();
-      }
-      const presetView = this.mergedConfigsData[0]?.presetView;
-      if (presetView) {
-        // pre-defined geojson view
-        const presetViewGeom = geoJsonFormat.readGeometry(presetView.features[0].geometry);
-        return presetViewGeom.getExtent();
       }
       if (this.indicator.aoi) {
         return transformExtent([this.indicator.lng, this.indicator.lat,


### PR DESCRIPTION
This PR adds the following:

 - prioritize preset view (if defined) over subAOI when selecting an indicator
 - only drag user back to inverse subAOI if map was moved via real user pan interaction
 - fix a vue-key used for destroying map components
 
 Note: this PR cherry-picked a commit from #1653, which should be treated first.  