### PR TITLE
fix: make geojson fetch errors fail silently

### DIFF
--- a/app/src/components/map/layers.js
+++ b/app/src/components/map/layers.js
@@ -31,18 +31,21 @@ function fetchGeoJsonFeatures(source, url) {
     .then((fStream) => {
       fStream.json()
         .then((geoJson) => {
-          geoJson.features.forEach((f) => {
-            if (f.id === null) {
-            // to do: some POIs (like bejing or LAX airports) have `null` set as feature ids,
-            // resulting in invalid geojson
-            // when this is fixed in the data, the normal geojson loader should be used
-            // eslint-disable-next-line no-param-reassign
-              f.id = undefined;
-            }
-          });
-          const features = geoJsonFormat.readFeatures(geoJson);
-          source.addFeatures(features);
-        });
+          if (geoJson.features && geoJson.features.length) {
+            geoJson.features.forEach((f) => {
+              if (f.id === null) {
+                // to do: some POIs (like bejing or LAX airports) have `null` set as feature ids,
+                // resulting in invalid geojson
+                // when this is fixed in the data, the normal geojson loader should be used
+                // eslint-disable-next-line no-param-reassign
+                f.id = undefined;
+              }
+            });
+            const features = geoJsonFormat.readFeatures(geoJson);
+            source.addFeatures(features);
+          }
+        })
+        .catch(() => {});
     });
 }
 


### PR DESCRIPTION
This PR makes errors when fetching GeoJSON features fail silently. This could happen when a faulty JSON-file is fetched, or the file is not available (e.g. invalid bounding box)