### PR TITLE
prevent dragback on global indicators

### DIFF
--- a/app/src/components/map/Map.vue
+++ b/app/src/components/map/Map.vue
@@ -5,6 +5,7 @@
     <SubaoiLayer
       :mapId="mapId"
       :indicator="indicator"
+      :isGlobal="isGlobalIndicator"
       v-if="dataLayerName"
       :key="dataLayerKey + '_subAoi'"
     />

--- a/app/src/components/map/SubaoiLayer.vue
+++ b/app/src/components/map/SubaoiLayer.vue
@@ -33,6 +33,7 @@ export default {
   props: {
     mapId: String,
     indicator: Object,
+    isGlobal: Boolean,
   },
   data: () => ({
     constrainingExtent: undefined,
@@ -125,7 +126,7 @@ export default {
       const feature = geoJsonFormat.readFeature(this.subAoi);
       subAoiLayer.getSource().addFeature(feature);
     }
-    if (this.isInverse && this.subAoi) {
+    if (this.isInverse && this.subAoi && !this.isGlobal) {
       // subaoi-geometry has a hole, use extent of that hole to constrain the view
       const insidePolygon = JSON.parse(JSON.stringify(this.subAoi));
       // eslint-disable-next-line prefer-destructuring


### PR DESCRIPTION
This PR fixes wrong dragbacks after userinteractions on some global indicators by disabling this functionality entirely for such indicators.