### PR TITLE
feat: create indicator registry

### DIFF
--- a/app/src/components/map/Map.vue
+++ b/app/src/components/map/Map.vue
@@ -118,7 +118,7 @@
       </div>
       <div class="pointerEvents mb-2">
         <AddToDashboardButton
-          v-if="mapId === 'centerMap' && indicator && isGlobalIndicator"
+          v-if="mapId === 'centerMap' && indicator && indicatorHasMapData(indicator)"
           :indicatorObject="indicator"
           :zoom="currentZoom"
           :center="currentCenter"

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -9,6 +9,7 @@ import { Feature } from 'ol';
 import { fromExtent } from 'ol/geom/Polygon';
 import { Stroke, Style } from 'ol/style';
 import getMapInstance from './components/map/map';
+import getLocationCode from './mixins/getLocationCode';
 
 export function padLeft(str, pad, size) {
   let out = str;
@@ -224,6 +225,11 @@ export function calculatePadding() {
   // handleDebugPolygon();
 }
 
+/**
+ * registry of "clean" indicators (input data filtered)
+ */
+const indicatorRegistry = {};
+
 export function getIndicatorFilteredInputData(selectedIndicator) {
   if (!selectedIndicator && !store.state.indicators.selectedIndicator) {
     return null;
@@ -234,6 +240,11 @@ export function getIndicatorFilteredInputData(selectedIndicator) {
   if (!inputData) {
     return null;
   }
+  const locationCode = getLocationCode(indicator);
+  if (indicatorRegistry[locationCode]) {
+    return indicatorRegistry[locationCode];
+  }
+
   // filter out rows which have empty "Input Data"
   const mask = inputData.map((item) => item !== '' && item !== '/');
   // filtering only arrays with more than 1 element to not fail on Input Data:['value'] shortcut
@@ -244,5 +255,6 @@ export function getIndicatorFilteredInputData(selectedIndicator) {
       }
     }
   }
+  indicatorRegistry[locationCode] = indicator;
   return indicator;
 }


### PR DESCRIPTION
This PR introduces one possible solution to reported infinite update loops via a registry object.

The problem seemed to be the manipulation of the arrays as a "cleaning" routine. This caused the `watchers` to fire, again manipulating the arrays.

Since this cleaning of invalid data entries should be necessary only once per indicator, later retrievals now always access the already clean indicator object.

Closes #1755 