### PR TITLE
fix: consistent layout when expanding datapanel with text only

### DIFF
--- a/app/src/components/DataPanel.vue
+++ b/app/src/components/DataPanel.vue
@@ -245,6 +245,17 @@
           </v-row>
         </v-col>
         <v-col
+          v-else-if="expanded"
+          :cols="$vuetify.breakpoint.mdAndDown || !expanded ? 12 : 6"
+          :style="`padding-bottom: 0px; height: ${$vuetify.breakpoint.mdAndDown
+                  ? 'auto'
+                  : (expanded
+                    ? wrapperHeight + 'px'
+                    : wrapperHeight - mapPanelHeight - (showMap ? 40 : 0)
+                    - buttonRowHeight
+                    - (multipleTabCompare ? 48 : 0) + 'px') }`"
+        />
+        <v-col
           :cols="$vuetify.breakpoint.mdAndDown || !expanded ? 12 : 6"
           :class="$vuetify.breakpoint.smAndUp ? 'scrollContainer' : ''"
           :style="`padding-bottom: 0px; height: ${$vuetify.breakpoint.mdAndDown


### PR DESCRIPTION
Before when expanding a POI that was text-only in the Datapanel the layout was inconsistent with our other POIs

<img width="1674" alt="Screenshot 2022-12-06 at 15 07 16" src="https://user-images.githubusercontent.com/17007165/205921164-3fe931b3-4d23-4600-b190-0744b8a9c772.png">

vs

<img width="1680" alt="Screenshot 2022-12-06 at 15 13 32" src="https://user-images.githubusercontent.com/17007165/205922123-7a19c14a-b1bd-4e5a-8103-21177f010cac.png">


With this PR the text should always stay on the right side when expanded

<img width="1680" alt="Screenshot 2022-12-06 at 15 14 56" src="https://user-images.githubusercontent.com/17007165/205922356-81ccb20a-3811-4c4e-adeb-6ef166d90fa0.png">
