### PR TITLE
move dark overlay to a separate component

### DIFF
--- a/app/src/components/AdminLayersInfoBar.vue
+++ b/app/src/components/AdminLayersInfoBar.vue
@@ -21,7 +21,7 @@
             single-line
             hide-details
             menu-props="auto"
-            :items="baseConfig.administrativeLayers"
+            :items="administrativeConfigs"
             item-value="id"
             item-text="name"
             v-model="currentAdminLevelModel"
@@ -98,12 +98,15 @@ export default {
     ...mapState('config', ['baseConfig']),
     allowedAdminLevels() {
       if (this.mergedConfigsData.adminLayersCustomIndicator?.adminZoneIds) {
-        const layers = this.baseConfig.administrativeLayers
+        const layers = this.administrativeConfigs
           .filter((l) => this.mergedConfigsData.adminLayersCustomIndicator?.adminZoneIds
             .includes(l.id));
         return layers;
       }
       return null;
+    },
+    administrativeConfigs() {
+      return this.mergedConfigsData.administrativeLayers || [];
     },
   },
   methods: {
@@ -111,13 +114,13 @@ export default {
       const { map } = getMapInstance('centerMap');
       const zoom = map.getView().getZoom();
       // taking the assumption of minZoom maxZoom logic to get currently displayed admin level
-      const adminLayerCurrentlyShown = this.baseConfig.administrativeLayers.find(
+      const adminLayerCurrentlyShown = this.administrativeConfigs.find(
         (l) => l.minZoom <= zoom && zoom <= l.maxZoom,
       );
       this.currentAdminLevelModel = adminLayerCurrentlyShown;
     },
     change(evt) {
-      const layer = this.baseConfig.administrativeLayers.find((i) => i.id === evt.id);
+      const layer = this.administrativeConfigs.find((i) => i.id === evt.id);
       const { map } = getMapInstance('centerMap');
       map.getView().animate({
         duration: 500,

--- a/app/src/components/DataPanel.vue
+++ b/app/src/components/DataPanel.vue
@@ -505,8 +505,8 @@ export default {
             const cKey = exportKeys[kk];
             let txtVal = '';
             if (cKey === 'aoi') {
-              if (i === 0 && this.$store.state.features.selectedArea !== null) {
-                txtVal = `"${wkt.read(JSON.stringify(this.$store.state.features.selectedArea)).write()}",`;
+              if (i === 0 && this.selectedArea !== null) {
+                txtVal = `"${wkt.read(JSON.stringify(this.selectedArea)).write()}",`;
               } else {
                 txtVal = ',';
               }

--- a/app/src/components/map/DarkOverlayLayer.vue
+++ b/app/src/components/map/DarkOverlayLayer.vue
@@ -1,0 +1,117 @@
+<script>
+import { getMapInstance } from '@/components/map/map';
+import GeoJSON from 'ol/format/GeoJSON';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import Style from 'ol/style/Style';
+import Fill from 'ol/style/Fill';
+import Stroke from 'ol/style/Stroke';
+import turfDifference from '@turf/difference';
+import { createLayerFromConfig } from '@/components/map/layers';
+import Group from 'ol/layer/Group';
+import {
+  mapState,
+} from 'vuex';
+
+const geoJsonFormat = new GeoJSON({});
+
+/**
+ */
+export default {
+  props: {
+    mapId: String,
+    configs: Array,
+  },
+  computed: {
+    ...mapState('config', [
+      'appConfig',
+    ]),
+  },
+  mounted() {
+    const { map } = getMapInstance(this.mapId);
+    const darkOverlayLayerGroups = this.configs.map((l) => createLayerFromConfig(l,
+      map,
+      {
+        zIndex: 5,
+      }));
+    this.darkOverlayLayerGroups = darkOverlayLayerGroups;
+    // setup listener on featuresloadend on first layer
+    const layer = this.getLayerFromGroup(
+      this.darkOverlayLayerGroups[0], this.configs[0],
+    );
+    darkOverlayLayerGroups.forEach((l) => {
+      map.addLayer(l);
+    });
+
+    const inverseStyle = new Style({
+      fill: new Fill({
+        color: 'rgba(0, 0, 0, 0.5)',
+      }),
+      stroke: new Stroke({
+        width: 2,
+        color: this.appConfig.branding.primaryColor,
+      }),
+    });
+
+    const inverseDarkOverlayLayer = new VectorLayer({
+      name: 'inverseDarkOverlayLayer',
+      zIndex: 4,
+      source: new VectorSource({}),
+      style: inverseStyle,
+    });
+    this.inverseDarkOverlayLayer = inverseDarkOverlayLayer;
+    map.addLayer(inverseDarkOverlayLayer);
+    layer.getSource().once('featuresloadend', this.setInitialInverseArea);
+  },
+  methods: {
+    getLayerFromGroup(layer, config) {
+      let foundLayer = null;
+      if (layer instanceof Group) {
+        foundLayer = layer.getLayers().getArray().find((l) => l.get('name') === config.name);
+      } else {
+        foundLayer = layer;
+      }
+      return foundLayer;
+    },
+    setInitialInverseArea() {
+      const layer = this.getLayerFromGroup(
+        this.darkOverlayLayerGroups[0], this.configs[0],
+      );
+      // get features and setup the inverse
+      const feature = layer.getSource().getFeatures()[0];
+      this.setupInverseFeatureLayer(feature);
+    },
+    setupInverseFeatureLayer(feature) {
+      // create inverse polygon geometry and add it to inverse layer
+      const globalBox = {
+        type: 'Feature',
+        properties: {},
+        geometry: {
+          type: 'Polygon',
+          coordinates: [[[-1800, -90], [1800, -90], [1800, 90], [-1800, 90], [-1800, -90]]],
+        },
+      };
+      const { map } = getMapInstance(this.mapId);
+      const featureGeomClone = feature.getGeometry().clone().transform(map.getView().getProjection(), 'EPSG:4326');
+      const diff = turfDifference(
+        globalBox, geoJsonFormat.writeGeometryObject(featureGeomClone),
+      );
+      const clone = feature.clone();
+      const transformedGeom = geoJsonFormat.readGeometry(diff.geometry, {
+        dataProjection: 'EPSG:4326',
+      }).transform('EPSG:4326', map.getView().getProjection());
+      clone.setGeometry(transformedGeom);
+      this.inverseDarkOverlayLayer.getSource().clear();
+      this.inverseDarkOverlayLayer.getSource().addFeature(clone);
+    },
+  },
+  beforeDestroy() {
+    const { map } = getMapInstance(this.mapId);
+    this.darkOverlayLayerGroups.forEach((layer) => {
+      map.removeLayer(layer);
+    });
+    map.removeLayer(this.inverseDarkOverlayLayer);
+  },
+  render: () => null,
+};
+</script>

--- a/app/src/components/map/Map.vue
+++ b/app/src/components/map/Map.vue
@@ -8,6 +8,13 @@
       v-if="administrativeConfigs.length > 0"
       :key="dataLayerName + '_adminLayers'"
     />
+    <!-- a layer adding a (potential) dark overlay, z-index 4 -->
+    <DarkOverlayLayer
+      :mapId="mapId"
+      :configs="darkOverlayLayers"
+      v-if="darkOverlayLayers.length > 0"
+      :key="dataLayerName + '_darkoverlay'"
+    />
     <!-- a layer adding a (potential) subaoi, z-index 5 -->
     <SubaoiLayer
       :mapId="mapId"
@@ -203,6 +210,7 @@ import MousePosition from 'ol/control/MousePosition';
 import { toStringXY } from 'ol/coordinate';
 import SubaoiLayer from '@/components/map/SubaoiLayer.vue';
 import AdminBordersLayers from '@/components/map/AdminBordersLayers.vue';
+import DarkOverlayLayer from '@/components/map/DarkOverlayLayer.vue';
 import Link from 'ol/interaction/Link';
 import {
   loadIndicatorExternalData,
@@ -228,6 +236,7 @@ export default {
     MapOverlay,
     IframeButton,
     AddToDashboardButton,
+    DarkOverlayLayer,
   },
   props: {
     mapId: {
@@ -319,8 +328,8 @@ export default {
       const configs = [...((
         this.mergedConfigsData.length && this.mergedConfigsData[0].overlayLayers
       ) || this.baseConfig.overlayLayersLeftMap)];
-      // administrativeLayers replace country vectors
-      if (!this.isGlobalIndicator && this.baseConfig.administrativeLayers?.length === 0) {
+      // darkOverlayLayers replace country vectors
+      if (!this.isGlobalIndicator && this.baseConfig.darkOverlayLayers?.length === 0) {
         configs.push({
           name: 'Country vectors',
           protocol: 'countries',
@@ -332,7 +341,12 @@ export default {
     },
     administrativeConfigs() {
       return (this.mergedConfigsData.length && this.mergedConfigsData[0].administrativeLayers)
-        || this.baseConfig.administrativeLayers;
+        || this.baseConfig.administrativeLayers || [];
+    },
+    darkOverlayLayers() {
+      // non-interactive layer definitions rendered as inverse semi-transparent overlay
+      return (this.mergedConfigsData.length && this.mergedConfigsData[0].darkOverlayLayers)
+        || this.baseConfig.darkOverlayLayers || [];
     },
     mapDefaults() {
       return {

--- a/app/src/components/map/SpecialLayer.vue
+++ b/app/src/components/map/SpecialLayer.vue
@@ -142,7 +142,7 @@ export default {
       map.un('pointermove', h);
     });
     if (this.resetProjectionOnDestroy) {
-      // reset to default map ection if different from it
+      // reset to default map projection if different from it
       const defaultProjection = store.state.config.baseConfig.defaultLayersDisplay.mapProjection;
       const projection = getProjectionOl(defaultProjection);
       if (map.getView().getProjection().getCode() !== projection?.getCode()) {

--- a/app/src/config/gtif.js
+++ b/app/src/config/gtif.js
@@ -220,14 +220,14 @@ const nutsStyle = {
   },
 };
 
-export const administrativeLayers = [{
+export const darkOverlayLayers = [{
   ...nutsStyle,
   name: 'NUTS L0',
   id: 'nuts_0',
   url: 'data/gtif/data/AT_NUTS_L0.geojson',
-  minZoom: 1,
-  maxZoom: 18,
 }];
+
+export const administrativeLayers = [];
 
 const completeAustriaAdministrativeLayers = [{
   ...nutsStyle,

--- a/app/src/store/modules/features.js
+++ b/app/src/store/modules/features.js
@@ -18,6 +18,7 @@ const state = {
     custom: [],
   },
   selectedArea: null,
+  selectedFeatures: [],
   adminBorderLayerSelected: null,
   adminBorderFeatureSelected: null,
 };
@@ -269,6 +270,9 @@ const mutations = {
     if (hasFeature('custom')) {
       state.featureFilters.custom = options.custom;
     }
+  },
+  SET_SELECTED_FEATURES(state, features) {
+    state.selectedFeatures = features;
   },
   SET_SELECTED_AREA(state, area) {
     state.selectedArea = area;


### PR DESCRIPTION
Minor refactor - moving austria overlay from admin layers to a separate component

Also fixes regression of admin layers not showing correctly in list after it has been made configurable which indicator has which admin borders