### PR TITLE
chore: add entries for .home domains for use with home dns

### DIFF
--- a/app/src/appConfig.js
+++ b/app/src/appConfig.js
@@ -6,7 +6,7 @@ module.exports = [
       staging: 2,
       production: 4,
     },
-    match: ['race.esa.int', 'eodash.eox.at', 'eodash-staging.eox.at', 'eodash-testing.eox.at', 'race.eox.world', 'race.localhost'],
+    match: ['race.esa.int', 'eodash.eox.at', 'eodash-staging.eox.at', 'eodash-testing.eox.at', 'race.eox.world', 'race.localhost', 'race.eox.home'],
     branding: {
       appName: 'Rapid Action for Citizens with Earth Observation',
       shortName: 'RACE Dashboard',
@@ -158,7 +158,7 @@ module.exports = [
       staging: 3,
       production: 5,
     },
-    match: ['eodashboard.org', 'www.eodashboard.org', 'eodash-trilateral.eox.at', 'eodash-trilateral-staging.eox.at', 'eodash-trilateral-testing.eox.at', 'trilateral.eox.world', 'trilateral.localhost'],
+    match: ['eodashboard.org', 'www.eodashboard.org', 'eodash-trilateral.eox.at', 'eodash-trilateral-staging.eox.at', 'eodash-trilateral-testing.eox.at', 'trilateral.eox.world', 'trilateral.localhost', 'trilateral.eox.home'],
     branding: {
       appName: 'Earth Observing Dashboard',
       primaryColor: '#333333',
@@ -254,7 +254,7 @@ module.exports = [
       staging: 6,
       production: 7,
     },
-    match: ['gtif.esa.int', 'gtif.eox.at', 'gtif-demo.eox.at', 'gtif-staging.eox.at', 'gtif-testing.eox.at', 'gtif.eox.world', 'gtif.localhost'],
+    match: ['gtif.esa.int', 'gtif.eox.at', 'gtif-demo.eox.at', 'gtif-staging.eox.at', 'gtif-testing.eox.at', 'gtif.eox.world', 'gtif.localhost', 'gtif.eox.home'],
     branding: {
       appName: 'Green Transition Information Factory',
       primaryColor: '#003247',


### PR DESCRIPTION
It is only possible to test the GTIF brand on another device as long as there is a dedicated DNS server in the network and as long as `appConfig.js` contains the appropriate domain names. 

This pull request adds three new domain names, each one ending with a `.home` TLD that is commonly agreed to be safe for home network usage: 

* [`race.eox.home`](http://race.eox.home:8812)
* [`trilateral.eox.home`](http://trilateral.eox.home:8812)
* [`gtif.eox.home`](http://gtif.eox.home:8812)

TODO: Into which branch should we merge this so it works for both `staging` and `gtif_staging`? Maybe just `gtif_staging` for now since the other two brands can be distinguished via IP/name?