### PR TITLE
fix: prevent recursive focusin handler calls by setting `retain-focus`  to false in dialog

### DIFF
--- a/app/src/components/CustomDashboardGrid.vue
+++ b/app/src/components/CustomDashboardGrid.vue
@@ -368,6 +368,7 @@
           <v-dialog
             v-model="dialog"
             width="500"
+            :retain-focus="false"
           >
             <v-card>
               <v-card-title class="headline primary--text mb-5">


### PR DESCRIPTION
This pull requests provides a simple change which fixes the freezing in custom dashboards on Firefox, something which is especially noticeable when opening the dialog for the second time since it causes the entire page to freeze.

Read more [in this GitHub issue thread of the `vuetify` project](https://github.com/vuetifyjs/vuetify/issues/8459).