### PR TITLE
Add 2022 OMI_trno2-COG layer

### DIFF
--- a/app/src/config/data_dates.json
+++ b/app/src/config/data_dates.json
@@ -9392,6 +9392,10 @@
         [
             "2021-01-01T00:00:00",
             "s3://veda-data-store-staging/OMI_trno2-COG/OMI_trno2_0.10x0.10_2021_Col3_V4.tif"
+        ],
+        [
+            "2022-01-01T00:00:00",
+            "s3://veda-data-store-staging/OMI_trno2-COG/OMI_trno2_0.10x0.10_2022_Col3_V4.tif"
         ]
     ],
     "OMSO2PCA-COG": [


### PR DESCRIPTION
We published a new OMI N02 layer for 2022 (https://github.com/NASA-IMPACT/veda-data-pipelines/issues/353). This change is intended to make it surface in your app.

https://eodashboard.org/explore?x=0&y=-927662.42328&z=2.90689&poi=W8-N9&search=World%3A+Nitrogen+Dioxide+%28yearly%29