### PR TITLE
Map chart time interaction

### DIFF
--- a/app/src/components/CustomDashboardGrid.vue
+++ b/app/src/components/CustomDashboardGrid.vue
@@ -811,7 +811,7 @@ export default {
           this.$set(this.serverUp, f.poi, f.mapInfo.up);
           this.$set(this.serverDataLayerTime, f.poi, f.mapInfo.dataLayerTime);
 
-          if (f.mapInfo.dataLayerTime) {
+          if (f.mapInfo.compareLayerTime) {
             this.$set(this.localCompareLayerTime, f.poi, f.mapInfo.compareLayerTime);
             this.$set(this.serverCompareLayerTime, f.poi, f.mapInfo.compareLayerTime);
           }

--- a/app/src/components/IndicatorData.vue
+++ b/app/src/components/IndicatorData.vue
@@ -1188,10 +1188,10 @@ export default {
     getChartObject() {
       if (this.$refs.lineChart) {
         return this.$refs.lineChart._data._chart;
-      } 
+      }
       if (this.$refs.barChart) {
         return this.$refs.barChart._data._chart;
-      } 
+      }
       if (this.$refs.scatterChart) {
         return this.$refs.scatterChart._data._chart;
       }

--- a/app/src/components/IndicatorData.vue
+++ b/app/src/components/IndicatorData.vue
@@ -100,7 +100,6 @@ import ScatterChart from '@/components/ScatterChart.vue';
 import MapChart from '@/components/MapChart.vue';
 import NUTS from '@/assets/NUTS_RG_03M_2016_4326_ESL2-DEL3.json';
 
-import { getMapInstance } from '@/components/map/map';
 import IndicatorTimeSelection from './IndicatorTimeSelection.vue';
 
 export default {
@@ -1231,17 +1230,17 @@ export default {
           const timeSelected = dataset.data[element._index].t;
           if (timeSelected && !this.$store.state.indicators.customAreaIndicator) {
             // reuse map event interface for scrolly
-            let command = "map:setTime";
+            let command = 'map:setTime';
             if (event.ctrlKey || event.shiftKey) {
-              command = "map:setCompareTime";
+              command = 'map:setCompareTime';
             }
             window.postMessage({
-              command, time:timeSelected,
+              command, time: timeSelected,
             });
             // highlight current item as a point
           }
         }
-      }
+      };
 
       // Default tooltips
       customSettings.tooltips = {

--- a/app/src/components/IndicatorData.vue
+++ b/app/src/components/IndicatorData.vue
@@ -100,6 +100,7 @@ import ScatterChart from '@/components/ScatterChart.vue';
 import MapChart from '@/components/MapChart.vue';
 import NUTS from '@/assets/NUTS_RG_03M_2016_4326_ESL2-DEL3.json';
 
+import { getMapInstance } from '@/components/map/map';
 import IndicatorTimeSelection from './IndicatorTimeSelection.vue';
 
 export default {
@@ -1221,6 +1222,27 @@ export default {
       let low = 0;
       let high = 0;
 
+      customSettings.onClick = (event, elements) => {
+        if (elements.length > 0) {
+          // clicked some chart
+          const chart = elements[0]._chart;
+          const element = chart.getElementAtEvent(event)[0];
+          const dataset = chart.data.datasets[element._datasetIndex];
+          const timeSelected = dataset.data[element._index].t;
+          if (timeSelected && !this.$store.state.indicators.customAreaIndicator) {
+            // reuse map event interface for scrolly
+            let command = "map:setTime";
+            if (event.ctrlKey || event.shiftKey) {
+              command = "map:setCompareTime";
+            }
+            window.postMessage({
+              command, time:timeSelected,
+            });
+            // highlight current item as a point
+          }
+        }
+      }
+
       // Default tooltips
       customSettings.tooltips = {
         callbacks: {
@@ -1361,28 +1383,6 @@ export default {
           };
         }
       }
-
-      /*
-      if (['AQ1'].includes(indicatorCode)) {
-        customSettings.tooltips = {
-          callbacks: {
-            label: (context, data) => {
-              debugger;
-              // const label = `${data.datasets[context.datasetIndex].label} measurement:
-              // ${Number(context.value)}`;
-              return label;
-            },
-            footer: (context) => {
-              debugger;
-              const { datasets } = this.datacollection;
-              const obj = datasets[context[0].datasetIndex].data[context[0].index];
-              const labelOutput = `Time: ${obj.referenceValue}`;
-              return labelOutput;
-            },
-          },
-        };
-      }
-      */
 
       if (indicatorCode === 'E10a5') {
         customSettings.yAxisRange = [

--- a/app/src/components/IndicatorData.vue
+++ b/app/src/components/IndicatorData.vue
@@ -1228,7 +1228,7 @@ export default {
           const element = chart.getElementAtEvent(event)[0];
           const dataset = chart.data.datasets[element._datasetIndex];
           const timeSelected = dataset.data[element._index].t;
-          if (timeSelected && !this.$store.state.indicators.customAreaIndicator) {
+          if (timeSelected) {
             // reuse map event interface for scrolly
             let command = 'map:setTime';
             if (event.ctrlKey || event.shiftKey) {
@@ -1237,7 +1237,6 @@ export default {
             window.postMessage({
               command, time: timeSelected,
             });
-            // highlight current item as a point
           }
         }
       };
@@ -1729,6 +1728,16 @@ export default {
           },
         };
       }
+      // add event listener for map up
+      window.addEventListener('message', (event) => {
+        if (event.data.command === 'chart:setTime' && event.data.time) {
+          console.log(event.data.time);
+        }
+
+        if (event.data.command === 'chart:setCompareTime' && event.data.time) {
+          console.log(event.data.time);
+        }
+      });
       return {
         ...customSettings,
         annotation: {

--- a/app/src/components/IndicatorData.vue
+++ b/app/src/components/IndicatorData.vue
@@ -1759,10 +1759,13 @@ export default {
         borderDash: [4, 4],
         borderWidth: 3,
         label: {
+          xPadding: 3,
+          yPadding: 3,
+          xAdjust: -28,
           enabled: true,
           content: 'Map layer',
           fontSize: 10,
-          backgroundColor: 'rgba(0,0,0,0.5)',
+          backgroundColor: 'rgba(0,0,0,0.4)',
         },
       };
 
@@ -1779,6 +1782,7 @@ export default {
           label: {
             ...defaultTimeAnnotation.label,
             content: 'Compare layer',
+            xAdjust: 38,
           },
         });
       }

--- a/app/src/components/IndicatorData.vue
+++ b/app/src/components/IndicatorData.vue
@@ -15,7 +15,7 @@
           style="position: absolute; right: 40px; top: 13px;display: none;"
           elevation="2"
           x-small
-          @click="resetBCZoom"
+          @click="resetZoom"
         >
           Reset Zoom
         </v-btn>
@@ -63,7 +63,7 @@
       style="position: absolute; right: 40px; top: 13px;display: none;"
       elevation="2"
       x-small
-      @click="resetSPZoom"
+      @click="resetZoom"
     >
       Reset Zoom
     </v-btn>
@@ -82,7 +82,7 @@
       style="position: absolute; right: 40px; top: 13px;display: none;"
       elevation="2"
       x-small
-      @click="resetLCZoom"
+      @click="resetZoom"
     >
       Reset Zoom
     </v-btn>
@@ -1185,17 +1185,22 @@ export default {
         this.compareLayerTimeFromMap = event.data.time;
       }
     },
-    resetLCZoom() {
-      this.extentChanged(false);
-      this.$refs.lineChart._data._chart.resetZoom();
+    getChartObject() {
+      if (this.$refs.lineChart) {
+        return this.$refs.lineChart._data._chart;
+      } 
+      if (this.$refs.barChart) {
+        return this.$refs.barChart._data._chart;
+      } 
+      if (this.$refs.scatterChart) {
+        return this.$refs.scatterChart._data._chart;
+      }
+      return null;
     },
-    resetBCZoom() {
+    resetZoom() {
       this.extentChanged(false);
-      this.$refs.barChart._data._chart.resetZoom();
-    },
-    resetSPZoom() {
-      this.extentChanged(false);
-      this.$refs.scatterChart._data._chart.resetZoom();
+      const chart = this.getChartObject();
+      chart.resetZoom();
     },
     formatNumRef(num, maxDecimals = 3) {
       return Number.parseFloat(num.toFixed(maxDecimals));
@@ -1790,6 +1795,9 @@ export default {
         ...customSettings,
         annotation: {
           annotations,
+        },
+        animation: {
+          duration: 0,
         },
         yAxis: this.indicatorObject.yAxis,
         xAxis: this.indicatorObject.xAxis,

--- a/app/src/components/map/Map.vue
+++ b/app/src/components/map/Map.vue
@@ -200,7 +200,6 @@ import { fetchCustomAreaObjects } from '@/helpers/customAreaObjects';
 import Attribution from 'ol/control/Attribution';
 import MousePosition from 'ol/control/MousePosition';
 import { toStringXY } from 'ol/coordinate';
-import { DateTime } from 'luxon';
 
 import SubaoiLayer from '@/components/map/SubaoiLayer.vue';
 import DarkOverlayLayer from '@/components/map/DarkOverlayLayer.vue';
@@ -424,7 +423,7 @@ export default {
      */
     specialLayerOptions() {
       return {
-        time: this.dataLayerTimeProp || this.dataLayerTime.value,
+        time: this.dataLayerTime.value,
         indicator: this.indicator?.indicator,
         aoiID: this.indicator?.aoiID,
         drawnArea: this.drawnArea,
@@ -896,15 +895,11 @@ export default {
     setInitialTime() {
       if (this.mergedConfigsData?.length) {
         if (this.dataLayerTimeProp) {
-          this.dataLayerTime = {
-            value: this.mergedConfigsData[0].usedTimes.time
-              .find((t) => t.includes(this.dataLayerTimeProp)),
-          };
+          this.dataLayerTime = this.availableTimeEntries
+            .find((item) => item.name === this.dataLayerTimeProp);
         } else if (this.mergedConfigsData[0].selectedTime) {
-          this.dataLayerTime = {
-            value: this.mergedConfigsData[0].usedTimes.time
-              .find((t) => t.includes(this.mergedConfigsData[0].selectedTime)),
-          };
+          this.dataLayerTime = this.availableTimeEntries
+            .find((item) => item.name === this.mergedConfigsData[0].selectedTime);
         } else {
           this.dataLayerTime = {
             value: this.mergedConfigsData[0].usedTimes.time[
@@ -913,10 +908,8 @@ export default {
           };
         }
         if (this.compareLayerTimeProp) {
-          this.compareLayerTime = {
-            value: this.mergedConfigsData[0].usedTimes.time
-              .find((t) => t.includes(this.compareLayerTimeProp)),
-          };
+          this.compareLayerTime = this.availableTimeEntries
+            .find((item) => item.name === this.compareLayerTimeProp);
         }
       }
     },

--- a/app/src/components/map/Map.vue
+++ b/app/src/components/map/Map.vue
@@ -617,24 +617,24 @@ export default {
         });
       } else {
         this.$emit('update:comparelayertime', enabled ? this.compareLayerTime.name : null);
-        if (enabled) {
-          window.postMessage({
-            command: 'chart:setCompareTime',
-            time: this.compareLayerTime.value.isLuxonDateTime
-              ? this.compareLayerTime.value.toISODate()
-              : this.compareLayerTime.value,
-          });
-        } else {
-          window.postMessage({
-            command: 'chart:setCompareTime',
-            time: null,
-          });
-        }
+      }
+      if (enabled) {
+        window.postMessage({
+          command: 'chart:setCompareTime',
+          time: this.compareLayerTime.value.isLuxonDateTime
+            ? this.compareLayerTime.value.toISODate()
+            : this.compareLayerTime.value,
+        });
+      } else {
+        window.postMessage({
+          command: 'chart:setCompareTime',
+          time: null,
+        });
       }
     },
     compareLayerTime(timeObj) {
       this.$emit('update:comparelayertime', this.enableCompare ? timeObj.name : null);
-      if (timeObj) {
+      if (timeObj && this.enableCompare) {
         window.postMessage({
           command: 'chart:setCompareTime',
           time: timeObj.value.isLuxonDateTime

--- a/app/src/components/map/SpecialLayer.vue
+++ b/app/src/components/map/SpecialLayer.vue
@@ -193,6 +193,7 @@ export default {
         this.singleClickHandlers.push(selectHandler);
       }
       if (config.getTimeFromProperty) {
+        // feature used to get time for layers from specific property
         const usedLayers = [layer.getLayers().getArray()[0]];
         const clickHandler = (e) => {
           const isCorrectSide = this.swipePixelX !== null

--- a/app/src/config/trilateral.js
+++ b/app/src/config/trilateral.js
@@ -693,7 +693,7 @@ export const layerNameMapping = Object.freeze({
   },
   'Sentinel-1': {
     layers: 'E8_SENTINEL1',
-    dateFormatFunction: shS2TimeFunction,
+    dateFormatFunction: shTimeFunction,
   },
   'ALOS-2': {
     layers: 'AWS_JAXA_CARS_CONTAINERS_ALOS2',

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -356,3 +356,10 @@ export function getPOIs() {
   });
   console.log(arr.join(','));
 }
+
+export const findClosest = (data, target = DateTime.now()) =>
+  data.reduce((prev, curr) => {
+    const a = Math.abs(curr.ts - target.ts);
+    const b = Math.abs(prev.ts - target.ts);
+    return a - b < 0 ? curr : prev;
+  });

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -357,9 +357,8 @@ export function getPOIs() {
   console.log(arr.join(','));
 }
 
-export const findClosest = (data, target = DateTime.now()) =>
-  data.reduce((prev, curr) => {
-    const a = Math.abs(curr.ts - target.ts);
-    const b = Math.abs(prev.ts - target.ts);
-    return a - b < 0 ? curr : prev;
-  });
+export const findClosest = (data, target = DateTime.now()) => data.reduce((prev, curr) => {
+  const a = Math.abs(curr.ts - target.ts);
+  const b = Math.abs(prev.ts - target.ts);
+  return a - b < 0 ? curr : prev;
+});


### PR DESCRIPTION
PR Adds two way interaction on time axis between main map and a chart (both custom area chart and the standard data chart)

Clicking on a dataset point on chart sets the map time closest to selected time. Same happens if shift or ctrl is hold for compare time selection (if compare is enabled). There is currently no counterpart of this functionality for ctrl/shift on mobile.

Similarly currently selected time/compare time is shown on a chart as a vertical annotation line.

Test deployments:

- https://eodash-testing.eox.at/map-chart-time-interaction/
- https://eodash-trilateral-testing.eox.at/map-chart-time-interaction/
- https://gtif-testing.eox.at/map-chart-time-interaction/