### PR TITLE
feat: integrate tooltip of protection zones

### DIFF
--- a/app/src/config/gtif.js
+++ b/app/src/config/gtif.js
@@ -264,8 +264,6 @@ const energyTransitionDefaults = {
   overlayLayers: [
     { ...overlayLayers.powerOpenInfrastructure, visible: true },
     { ...overlayLayers.eoxOverlay, visible: true },
-    { ...overlayLayers.protectionZones },
-    { ...overlayLayers.protectionZonesNatura },
     {
       protocol: 'GeoJSON',
       visible: false,
@@ -765,6 +763,10 @@ function createREP1Config(indicatorCode, rasterFileUrl) {
           },
           tooltip: true,
           allowedParameters: ['name'],
+        }, {
+          ...overlayLayers.protectionZones,
+        }, {
+          ...overlayLayers.protectionZonesNatura,
         }],
       },
     },
@@ -838,7 +840,7 @@ function createREP2Config(indicatorCode, rasterFileUrl, min, max) {
             },
           },
         },
-        display: {
+        display: [{
           dataInfo: 'GlobalHorizontalIrradiation',
           protocol: 'cog',
           id: 'REP2',
@@ -904,7 +906,11 @@ function createREP2Config(indicatorCode, rasterFileUrl, min, max) {
             ],
           },
           name: 'Solar Energy',
-        },
+        }, {
+          ...overlayLayers.protectionZones,
+        }, {
+          ...overlayLayers.protectionZonesNatura,
+        }],
       },
     },
   };

--- a/app/src/config/layers.js
+++ b/app/src/config/layers.js
@@ -252,6 +252,8 @@ export const overlayLayers = Object.freeze({
       fillColor: '#99cc3388',
       strokeColor: '#339900',
     },
+    tooltip: true,
+    allowedParameters: ['sitename'],
   },
   protectionZonesNatura: {
     name: 'Protected areas (Natura 2000)',
@@ -263,6 +265,8 @@ export const overlayLayers = Object.freeze({
       fillColor: '#99cc3388',
       strokeColor: '#339900',
     },
+    tooltip: true,
+    allowedParameters: ['sitename'],
   },
 });
 


### PR DESCRIPTION
close https://github.com/eurodatacube/eodash/issues/2465
Needed to move the protected areas to analysis layers otherwise tooltip can not be configured now, I hope that is fine
https://gtif-testing.eox.at/protected-areas-tooltips/?indicator=REP1_1