### PR TITLE
feat: draw tools integration and measurements

### DIFF
--- a/app/src/components/map/Map.vue
+++ b/app/src/components/map/Map.vue
@@ -141,6 +141,11 @@
           interval="1000"
           :endpoint="searchEndpoint"
         ></eox-geosearch>
+        <eox-drawtools
+          type="Polygon"
+          for="eox-map"
+          style="pointer-events: initial"
+        />
         <v-btn
           v-if="$vuetify.breakpoint.xsOnly && displayTimeSelection"
           :color="$vuetify.theme.currentTheme.background"
@@ -276,6 +281,7 @@ import {
   getFilteredInputData,
 } from '@/utils';
 import '@eox/map';
+import '@eox/drawtools';
 
 const geoJsonFormat = new GeoJSON({
 });

--- a/app/vue.config.js
+++ b/app/vue.config.js
@@ -60,6 +60,7 @@ module.exports = {
     '@eox/storytelling',
     'color-parse',
     '@eox/geosearch',
+    '@eox/drawtools',
   ],
   configureWebpack: {
     devServer: {


### PR DESCRIPTION
Integrates the `EOxDrawTools` element into the GTIF branch of eodash, enabling the user to perform line and area measurements. Do note that the branch version of the element must be used as the branch is not yet merged in the EOxElements.

The current approach of the draw tools is to display both the "Create Geometry" and "Delete Geometry" buttons at the same time, while in `eodash` we only allow creating a single geometry at a time. This still needs some work to be properly integrated with the other map buttons.

Furthermore it should also be verified that the `drawnArea` is set correctly in the store after the user updates the geometry.